### PR TITLE
[#28] 프로필 오류 해결 및 접근 설정 수정

### DIFF
--- a/src/main/java/com/goorm/team9/icontact/common/error/ClientErrorCode.java
+++ b/src/main/java/com/goorm/team9/icontact/common/error/ClientErrorCode.java
@@ -11,10 +11,11 @@ public enum ClientErrorCode implements ErrorCodeInterface {
     // Client 관련 커스텀 에러는 10XX 의 형식을 사용
     CLIENT_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 1001, "해당 프로필을 찾을 수 없습니다."),
     STATUS_IS_PRIVATE(HttpStatus.FORBIDDEN.value(), 1002, "해당 프로필은 비공개 상태입니다."),
-    EXISTED_EMAIL(HttpStatus.CONFLICT.value(), 1003, "이미 존재하는 이메일입니다.");
+    EXISTED_EMAIL(HttpStatus.CONFLICT.value(), 1003, "이미 존재하는 이메일입니다."),
+    NO_CHAT_OPPORTUNITY(HttpStatus.BAD_REQUEST.value(), 1004, "더 이상 채팅방을 만들 수 없습니다."),
+    CHAT_OPPORTUNITY_FULL(HttpStatus.BAD_REQUEST.value(), 1005, "채팅 기회가 이미 최대치입니다.");
 
     private final Integer httpStatusCode;
     private final Integer errorCode;
     private final String description;
-
 }

--- a/src/main/java/com/goorm/team9/icontact/common/error/MemoErrorCode.java
+++ b/src/main/java/com/goorm/team9/icontact/common/error/MemoErrorCode.java
@@ -1,0 +1,20 @@
+package com.goorm.team9.icontact.common.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MemoErrorCode implements ErrorCodeInterface {
+
+    // Memo 관련 커스텀 에러는 20XX 의 형식을 사용
+    MEMO_WRITER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 2001, "작성자 정보를 찾을 수 없습니다."),
+    MEMO_TARGET_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 2002, "대상 사용자 정보를 찾을 수 없습니다."),
+    MEMO_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 2003, "해당 메모를 찾을 수 없습니다.");
+
+    private final Integer httpStatusCode;
+    private final Integer errorCode;
+    private final String description;
+
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/client/controller/ClientController.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/client/controller/ClientController.java
@@ -72,12 +72,12 @@ public class ClientController {
             @PathVariable Long client_Id,
             @Parameter(description = "닉네임", example = "Noah2222")
             @RequestParam(required = false) String nickName,
-            @Parameter(description = "직업 (예: '개발자')", example = "개발자")
-            @RequestParam(required = false) String roleDescription,
-            @Parameter(description = "경력 (예: '주니어')", example = "주니어")
-            @RequestParam(required = false) String careerDescription,
-            @Parameter(description = "공개 여부 (예: '공개')", example = "공개")
-            @RequestParam(required = false) String statusDescription,
+            @Parameter(description = "직업", example = "DEV")
+            @RequestParam(required = false) Role role,
+            @Parameter(description = "경력", example = "JUNIOR")
+            @RequestParam(required = false) Career career,
+            @Parameter(description = "공개 여부", example = "PUBLIC")
+            @RequestParam(required = false) Status status,
             @Parameter(description = "소개글", example = "안녕하세요. 바뀐 개발자입니다.")
             @RequestParam(required = false) String introduction,
             @Parameter(description = "접근 링크", example = "https://www.test22.com")
@@ -95,13 +95,28 @@ public class ClientController {
             @Parameter(description = "주력 프레임워크")
             @RequestParam(required = false) Framework framework
     ) {
-        Role role = (roleDescription != null) ? Role.fromDescription(roleDescription) : null;
-        Career career = (careerDescription != null) ? Career.fromDescription(careerDescription) : null;
-        Status status = (statusDescription != null) ? Status.fromDescription(statusDescription) : null;
-
         return ResponseEntity.ok(clientService.updateUser(
                 client_Id, nickName, role, career, status, introduction, link, profileImage,
                 topic1, topic2, topic3, language, framework
         ));
     }
+
+    @PatchMapping("/{client_Id}/reduce-chat-opportunity")
+    @Operation(summary = "채팅 기회 감소 API", description = "채팅방을 만들면 기회를 1 감소시킵니다.")
+    public ResponseEntity<String> reduceChatOpportunity(
+            @PathVariable Long client_Id
+    ) {
+        clientService.reduceChatOpportunity(client_Id);
+        return ResponseEntity.ok("채팅 기회가 1 감소되었습니다.");
+    }
+
+    @PatchMapping("/{client_Id}/increase-chat-opportunity")
+    @Operation(summary = "채팅 기회 증가 API", description = "특정 조건에서 채팅방 생성 기회를 1 증가시킵니다.")
+    public ResponseEntity<String> increaseChatOpportunity(
+            @PathVariable Long client_Id
+    ) {
+        clientService.increaseChatOpportunity(client_Id);
+        return ResponseEntity.ok("채팅 기회가 1 증가되었습니다.");
+    }
+
 }

--- a/src/main/java/com/goorm/team9/icontact/domain/client/controller/MemoController.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/client/controller/MemoController.java
@@ -1,0 +1,43 @@
+package com.goorm.team9.icontact.domain.client.controller;
+
+import com.goorm.team9.icontact.domain.client.dto.response.MemoResponseDTO;
+import com.goorm.team9.icontact.domain.client.service.MemoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/memo")
+@RequiredArgsConstructor
+@Tag(name = "Memo API", description = "사용자 메모 관련 API")
+public class MemoController {
+
+    private final MemoService memoService;
+
+    @PostMapping("/create")
+    @Operation(summary = "메모 작성", description = "특정 사용자에게 개인 메모를 남깁니다.")
+    public ResponseEntity<MemoResponseDTO> createMemo(
+            @Parameter(description = "작성자 ID") @RequestParam Long writerId,
+            @Parameter(description = "대상 사용자 ID") @RequestParam Long targetId,
+            @Parameter(description = "메모 내용") @RequestParam String content) {
+        return ResponseEntity.ok(memoService.createMemo(writerId, targetId, content));
+    }
+
+    @GetMapping("/writer/{writerId}")
+    @Operation(summary = "내가 남긴 메모 조회", description = "내가 남긴 모든 메모를 가져옵니다.")
+    public ResponseEntity<List<MemoResponseDTO>> getMemosByWriter(@PathVariable Long writerId) {
+        return ResponseEntity.ok(memoService.getMemosByWriter(writerId));
+    }
+
+    @DeleteMapping("/delete")
+    @Operation(summary = "메모 삭제", description = "메모를 삭제합니다.")
+    public ResponseEntity<Void> deleteMemo(@Parameter(description = "메모 ID") @RequestParam Long memoId) {
+        memoService.deleteMemo(memoId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/client/dto/request/MemoRequestDTO.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/client/dto/request/MemoRequestDTO.java
@@ -1,0 +1,11 @@
+package com.goorm.team9.icontact.domain.client.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MemoRequestDTO {
+    private Long targetId;
+    private String content;
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/client/dto/response/MemoResponseDTO.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/client/dto/response/MemoResponseDTO.java
@@ -1,0 +1,19 @@
+package com.goorm.team9.icontact.domain.client.dto.response;
+
+import com.goorm.team9.icontact.domain.client.entity.MemoEntity;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MemoResponseDTO {
+    private Long id;
+    private Long targetId;
+    private String content;
+
+    public MemoResponseDTO(MemoEntity memo) {
+        this.id = memo.getId();
+        this.targetId = memo.getTarget().getId();
+        this.content = memo.getContent();
+    }
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/client/entity/ClientEntity.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/client/entity/ClientEntity.java
@@ -52,7 +52,7 @@ public class ClientEntity extends BaseTimeEntity {
     @Column
     private String profileImage;
 
-    @Column(name = "chat_opportunity")
+    @Column(name = "chat_opportunity", nullable = false)
     private int chatOpportunity;
 
     @Column(name = "chat_message")
@@ -69,6 +69,13 @@ public class ClientEntity extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "client_id", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OAuth> oauthAccounts = new ArrayList<>(); // 한 User가 여러 OAuth 계정을 가짐
+
+    public void setChatOpportunity(int chatOpportunity) {
+        if (chatOpportunity < 0 || chatOpportunity > 5) {
+            throw new IllegalArgumentException("채팅 기회는 0~5 사이의 값이어야 합니다.");
+        }
+        this.chatOpportunity = chatOpportunity;
+    }
 
     public void setDeleted(boolean deleted) {
         this.isDeleted = deleted;

--- a/src/main/java/com/goorm/team9/icontact/domain/client/entity/MemoEntity.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/client/entity/MemoEntity.java
@@ -1,0 +1,50 @@
+package com.goorm.team9.icontact.domain.client.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Builder
+@Table(name = "memo")
+public class MemoEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id", nullable = false)
+    private ClientEntity writer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_id", nullable = false)
+    private ClientEntity target;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/client/repository/MemoRepository.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/client/repository/MemoRepository.java
@@ -1,0 +1,14 @@
+package com.goorm.team9.icontact.domain.client.repository;
+
+import com.goorm.team9.icontact.domain.client.entity.MemoEntity;
+import com.goorm.team9.icontact.domain.client.entity.ClientEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MemoRepository extends JpaRepository<MemoEntity, Long> {
+    List<MemoEntity> findByWriter(ClientEntity writer);
+    List<MemoEntity> findByTarget(ClientEntity target);
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/client/service/ImageFileStorageService.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/client/service/ImageFileStorageService.java
@@ -34,7 +34,7 @@ public class ImageFileStorageService {
     }
 
     public void deleteFile(String filePath) {
-        if (filePath == null || filePath.equals(DEFAULT_IMAGE)) {
+        if (filePath == null || isDefaultImage(filePath)) {
             return;
         }
         try {
@@ -46,7 +46,7 @@ public class ImageFileStorageService {
     }
 
     public boolean isDefaultImage(String filePath) {
-        return filePath.equals(DEFAULT_IMAGE);
+        return filePath == null || filePath.endsWith("default_profile_image.jpg");
     }
-
 }
+

--- a/src/main/java/com/goorm/team9/icontact/domain/client/service/MemoService.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/client/service/MemoService.java
@@ -1,0 +1,59 @@
+package com.goorm.team9.icontact.domain.client.service;
+
+import com.goorm.team9.icontact.common.exception.CustomException;
+import com.goorm.team9.icontact.common.error.MemoErrorCode;
+import com.goorm.team9.icontact.domain.client.dto.response.MemoResponseDTO;
+import com.goorm.team9.icontact.domain.client.entity.ClientEntity;
+import com.goorm.team9.icontact.domain.client.entity.MemoEntity;
+import com.goorm.team9.icontact.domain.client.repository.MemoRepository;
+import com.goorm.team9.icontact.domain.client.repository.ClientRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MemoService {
+
+    private final MemoRepository memoRepository;
+    private final ClientRepository clientRepository;
+
+    @Transactional
+    public MemoResponseDTO createMemo(Long writerId, Long targetId, String content) {
+        ClientEntity writer = clientRepository.findById(writerId)
+                .orElseThrow(() -> new CustomException(MemoErrorCode.MEMO_WRITER_NOT_FOUND));
+
+        ClientEntity target = clientRepository.findById(targetId)
+                .orElseThrow(() -> new CustomException(MemoErrorCode.MEMO_TARGET_NOT_FOUND));
+
+        MemoEntity memo = MemoEntity.builder()
+                .writer(writer)
+                .target(target)
+                .content(content)
+                .build();
+
+        memoRepository.save(memo);
+        return new MemoResponseDTO(memo);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MemoResponseDTO> getMemosByWriter(Long writerId) {
+        ClientEntity writer = clientRepository.findById(writerId)
+                .orElseThrow(() -> new CustomException(MemoErrorCode.MEMO_WRITER_NOT_FOUND));
+
+        return memoRepository.findByWriter(writer).stream()
+                .map(MemoResponseDTO::new)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void deleteMemo(Long memoId) {
+        if (!memoRepository.existsById(memoId)) {
+            throw new CustomException(MemoErrorCode.MEMO_NOT_FOUND);
+        }
+        memoRepository.deleteById(memoId);
+    }
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/sociallogin/controller/AuthController.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/sociallogin/controller/AuthController.java
@@ -3,6 +3,8 @@ package com.goorm.team9.icontact.domain.sociallogin.controller;
 import com.goorm.team9.icontact.domain.sociallogin.dto.JwtResponse;
 import com.goorm.team9.icontact.domain.sociallogin.dto.OAuthLoginRequest;
 import com.goorm.team9.icontact.domain.sociallogin.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,7 @@ import java.util.Map;
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
+@Tag(name = "Auth API", description = "사용자 인증 관련 API 입니다.")
 public class AuthController {
 
     private final AuthService authService;
@@ -32,6 +35,7 @@ public class AuthController {
      * 서버 상태 확인용 엔드포인트
      */
     @GetMapping("/home")
+    @Operation(summary = "서버 상태 확인 API", description = "서버의 상태를 확인하는 API 입니다.")
     public String home() {
         return "Hello, Home!";
     }
@@ -42,6 +46,7 @@ public class AuthController {
      * @return JWT 토큰 반환
      */
     @PostMapping("/github")
+    @Operation(summary = "GitHub 로그인 API", description = "GitHub OAuth를 사용하여 로그인하고 JWT 토큰을 반환합니다.")
     public ResponseEntity<JwtResponse> loginWithGithub(@RequestBody OAuthLoginRequest request) {
         logger.info("🔄 GitHub OAuth 로그인 요청: 받은 코드={}", request.getCode());
         if (request.getCode() == null || request.getCode().isEmpty()) {
@@ -59,6 +64,7 @@ public class AuthController {
      * - 쿠키 삭제
      */
     @PostMapping("/logout")
+    @Operation(summary = "로그아웃 API", description = "현재 사용자의 토큰을 블랙리스트에 추가하고, 세션을 무효화한 후 쿠키를 삭제합니다.")
     public ResponseEntity<String> logout(HttpServletRequest request, HttpServletResponse response) {
         authService.logout(request, response);
         return ResponseEntity.ok("로그아웃 완료 ✅");
@@ -69,6 +75,7 @@ public class AuthController {
      * - 토큰이 블랙리스트에 있는지 확인
      */
     @GetMapping("/token-status")
+    @Operation(summary = "토큰 블랙리스트 확인 API", description = "JWT 토큰이 블랙리스트에 있는지 확인하여 반환합니다.")
     public ResponseEntity<Map<String, Boolean>> checkTokenStatus(@RequestHeader(name = "Authorization", required = false) String authHeader) {
         boolean isBlacklisted = authHeader != null && authService.isTokenBlacklisted(authHeader);
         return ResponseEntity.ok(Map.of("blacklisted", isBlacklisted));
@@ -80,6 +87,7 @@ public class AuthController {
      * - 로그아웃 로직과 동일하게 처리
      */
     @PostMapping("/withdraw")
+    @Operation(summary = "회원 탈퇴 API", description = "현재 사용자의 계정을 소프트 삭제 처리합니다. 로그아웃 로직과 동일한 절차를 따릅니다.")
     public ResponseEntity<String> withdraw(HttpServletRequest request, HttpServletResponse response) {
         return authService.withdraw(request, response);
     }


### PR DESCRIPTION
## 📋 Summary

> - closes #28 
> - 프로필 이미지 삭제 오류 및 개인 메모 기능을 구현합니다.

## ✅ Tasks

- 사용자 프로필 변경시 시나리오

사용자의 액션 | 기존 이미지 | 새로운 이미지 | 결과
-- | -- | -- | --
기본 이미지 사용 중, 새로운 이미지 업로드 | 기본 이미지 | 커스텀 이미지 | 기존 이미지 유지, 새 이미지 저장
커스텀 이미지 사용 중, 새로운 이미지 업로드 | 커스텀 이미지 | 새로운 커스텀 이미지 | 기존 커스텀 이미지 삭제 후 새 이미지 저장
커스텀 이미지 사용 중, 기본 이미지로 변경 | 커스텀 이미지 | 기본 이미지 | 기존 이미지 삭제 후 기본 이미지 저장
기본 이미지 사용 중, 기본 이미지 유지 | 커스텀 이미지 | 없음 | 아무 작업도 하지 않음
---
- 채팅방 개설 기회를 조정할 수 있는 로직을 추가합니다.
- 상대방 프로필에 남길 메모 기능을 구현합니다.
- 메모 기능은 기능은 개발하였으나 추가 사항이었기에 적용은 선택사항 입니다.

## ✏️ To Reviewer

배포 서버 스웨거의 API가 안 보이는 현상은 해결하지 못 했습니다.
소셜 로그인 관련 보안 설정 코드를 수정했지만 해결하지 못 했습니다.
남은 코드 관련해서 리뷰 부탁드립니다!!

## 📷 Screenshot

❌
