### PR TITLE
[#31] feat: 소셜 로그인 : 구글 & 카카오

### DIFF
--- a/src/main/java/com/goorm/team9/icontact/config/security/SecurityConfig.java
+++ b/src/main/java/com/goorm/team9/icontact/config/security/SecurityConfig.java
@@ -106,16 +106,6 @@ public class SecurityConfig {
                         .clearAuthentication(true)    // 인증 정보 삭제
                         .deleteCookies("JSESSIONID", "Authorization") // 쿠키 삭제
                 )
-                // 인증되지 않은 경우, 보호된 API만 401 응답
-//                .exceptionHandling(exception -> exception
-//                        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)) // ✅ 모든 보호된 리소스에 대해 401 반환
-//                )
-//                .exceptionHandling(exception -> exception
-//                        .defaultAuthenticationEntryPointFor(
-//                                new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED), // 보호된 API 접근 시 401 응답
-//                                request -> request.getRequestURI().startsWith("/auth/home") // 여기만 401
-//                        )
-//                )
                 .exceptionHandling(exception -> exception
                         .defaultAuthenticationEntryPointFor(
                                 new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED), // 보호된 API 접근 시 401 응답

--- a/src/main/java/com/goorm/team9/icontact/config/security/SecurityConfig.java
+++ b/src/main/java/com/goorm/team9/icontact/config/security/SecurityConfig.java
@@ -69,7 +69,7 @@ public class SecurityConfig {
                 )
                 .oauth2Login(oauth2 -> oauth2
                         .redirectionEndpoint(redirection -> redirection
-                                .baseUri("/login/oauth2/code/github")
+                                .baseUri("/login/oauth2/code/*")
                         )
                         .userInfoEndpoint(userInfo -> userInfo
                                 .userService(customOAuth2UserService)

--- a/src/main/java/com/goorm/team9/icontact/config/security/SecurityConfig.java
+++ b/src/main/java/com/goorm/team9/icontact/config/security/SecurityConfig.java
@@ -106,13 +106,10 @@ public class SecurityConfig {
                         .clearAuthentication(true)    // 인증 정보 삭제
                         .deleteCookies("JSESSIONID", "Authorization") // 쿠키 삭제
                 )
-
                 // 인증되지 않은 경우, 보호된 API만 401 응답
-
 //                .exceptionHandling(exception -> exception
 //                        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)) // ✅ 모든 보호된 리소스에 대해 401 반환
 //                )
-
 //                .exceptionHandling(exception -> exception
 //                        .defaultAuthenticationEntryPointFor(
 //                                new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED), // 보호된 API 접근 시 401 응답

--- a/src/main/java/com/goorm/team9/icontact/config/security/SecurityConfig.java
+++ b/src/main/java/com/goorm/team9/icontact/config/security/SecurityConfig.java
@@ -6,12 +6,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 
@@ -77,6 +75,7 @@ public class SecurityConfig {
                                 .userService(customOAuth2UserService)
                         )
                         .successHandler(new JwtAuthenticationSuccessHandler(jwtTokenProvider)) // JWT 발급 후 반환
+                        .defaultSuccessUrl("/auth/home", true) // 성공 후 이동할 URL 지정
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, jwtBlacklist),
                         UsernamePasswordAuthenticationFilter.class) // JWT 필터 적용
@@ -90,12 +89,16 @@ public class SecurityConfig {
                 )
 
                 // 인증되지 않은 경우, 보호된 API만 401 응답
-                .exceptionHandling(exception -> exception
-                        .defaultAuthenticationEntryPointFor(
-                                new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED), // 보호된 API 접근 시 401 응답
-                                request -> request.getRequestURI().startsWith("/auth/home") // 여기만 401
-                        )
-                )
+//                .exceptionHandling(exception -> exception
+//                        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)) // ✅ 모든 보호된 리소스에 대해 401 반환
+//                )
+
+//                .exceptionHandling(exception -> exception
+//                        .defaultAuthenticationEntryPointFor(
+//                                new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED), // 보호된 API 접근 시 401 응답
+//                                request -> request.getRequestURI().startsWith("/auth/home") // 여기만 401
+//                        )
+//                )
 
                 .csrf(csrf -> csrf.disable())
                 .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()))

--- a/src/main/java/com/goorm/team9/icontact/domain/sociallogin/controller/AuthController.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/sociallogin/controller/AuthController.java
@@ -85,8 +85,6 @@ public class AuthController {
         return ResponseEntity.ok(new JwtResponse(jwt));
     }
 
-
-
     /**
      * 로그아웃 API
      * - 블랙리스트에 토큰 추가

--- a/src/main/java/com/goorm/team9/icontact/domain/sociallogin/controller/AuthController.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/sociallogin/controller/AuthController.java
@@ -53,9 +53,39 @@ public class AuthController {
             logger.error("❌ GitHub OAuth 로그인 실패: 받은 코드가 없음!");
             throw new RuntimeException("GitHub OAuth 인증 코드가 없습니다.");
         }
-        String jwt = authService.loginWithGithub(request.getCode());
+        String jwt = authService.loginWithGithub("github", request.getCode());
         return ResponseEntity.ok(new JwtResponse(jwt));
     }
+
+    @PostMapping("/google")
+    @Operation(summary = "Google 로그인 API", description = "Google OAuth를 사용하여 로그인하고 JWT 토큰을 반환합니다.")
+    public ResponseEntity<JwtResponse> loginWithGoogle(@RequestBody OAuthLoginRequest request) {
+        logger.info("🔄 Google OAuth 로그인 요청: 받은 코드={}", request.getCode());
+
+        if (request.getCode() == null || request.getCode().isEmpty()) {
+            logger.error("❌ Google OAuth 로그인 실패: 받은 코드가 없음!");
+            throw new RuntimeException("Google OAuth 인증 코드가 없습니다.");
+        }
+
+        String jwt = authService.loginWithGithub("google", request.getCode());
+        return ResponseEntity.ok(new JwtResponse(jwt));
+    }
+
+    @PostMapping("/kakao")
+    @Operation(summary = "Kakao 로그인 API", description = "Kakao OAuth를 사용하여 로그인하고 JWT 토큰을 반환합니다.")
+    public ResponseEntity<JwtResponse> loginWithKakao(@RequestBody OAuthLoginRequest request) {
+        logger.info("🔄 Kakao OAuth 로그인 요청: 받은 코드={}", request.getCode());
+
+        if (request.getCode() == null || request.getCode().isEmpty()) {
+            logger.error("❌ Kakao OAuth 로그인 실패: 받은 코드가 없음!");
+            throw new RuntimeException("Kakao OAuth 인증 코드가 없습니다.");
+        }
+
+        String jwt = authService.loginWithGithub("kakao", request.getCode());
+        return ResponseEntity.ok(new JwtResponse(jwt));
+    }
+
+
 
     /**
      * 로그아웃 API

--- a/src/main/java/com/goorm/team9/icontact/domain/sociallogin/security/jwt/JwtAuthenticationSuccessHandler.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/sociallogin/security/jwt/JwtAuthenticationSuccessHandler.java
@@ -37,7 +37,16 @@ public class JwtAuthenticationSuccessHandler extends SimpleUrlAuthenticationSucc
         // JWT 생성 전 email 값 검증 추가
         if (email == null || "no-email".equals(email)) {
             logger.error("❌ JWT 발급 실패: 유효한 이메일 정보가 없습니다.");
-            throw new RuntimeException("JWT 발급 실패: 유효한 이메일 정보가 없습니다.");
+
+            response.setContentType("application/json");
+            response.setCharacterEncoding("UTF-8");
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401 응답
+
+            Map<String, String> errorResponse = new HashMap<>();
+            errorResponse.put("error", "JWT 발급 실패: 유효한 이메일 정보가 없습니다.");
+
+            response.getWriter().write(new ObjectMapper().writeValueAsString(errorResponse));
+            return; // 예외를 던지지 않고 여기서 종료
         }
 
         String jwtToken = jwtTokenProvider.createToken(email); // JWT 생성
@@ -47,8 +56,8 @@ public class JwtAuthenticationSuccessHandler extends SimpleUrlAuthenticationSucc
 
         logger.info("✅ 생성된 JWT 토큰: {}", jwtToken);
 
-        // 필요 시 특정 페이지로 리다이렉트 가능! 지금은 일단 홈으로!
-        response.sendRedirect("/auth/home");
+        // 필요 시 특정 페이지로 리다이렉트하도록, 지금은 기본 처리 유지
+        clearAuthenticationAttributes(request);
     }
 
     /**

--- a/src/main/java/com/goorm/team9/icontact/domain/sociallogin/security/provider/GitHubOAuthProvider.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/sociallogin/security/provider/GitHubOAuthProvider.java
@@ -1,30 +1,17 @@
 package com.goorm.team9.icontact.domain.sociallogin.security.provider;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Set;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
+
 import java.util.Map;
 
-/**
- * GitHub OAuth Provider
- * - GitHub API와 통신하여 사용자 정보를 가져옴.
- */
 @Service
-public class GitHubOAuthProvider {
+public class GitHubOAuthProvider implements OAuthProvider {
 
     @Value("${GITHUB_CLIENT_ID}")
     private String clientId;
@@ -33,52 +20,15 @@ public class GitHubOAuthProvider {
     private String clientSecret;
 
     @Value("${GITHUB_REDIRECT_URI}")
-    private String githubRedirectUri;
+    private String redirectUri;
 
-    private final RestTemplate restTemplate = new RestTemplate(); // REST API 요청을 보낼 객체 생성
-    private static final Logger logger = LoggerFactory.getLogger(GitHubOAuthProvider.class);
-
-    // 사용된 OAuth code 저장 (중복 방지)
-    private static final Set<String> usedCodes = new HashSet<>();
-
-    /**
-     * GitHub에서 사용자 정보를 가져오는 메서드
-     * - GitHub에 `code`를 보내 `access_token` 요청
-     * - GitHub에 `access_token`을 보내 `user 정보` 요청
-     */
-    public Map<String, Object> getUserInfo(String code) {
-        logger.info("🔄 GitHub OAuth 인증 요청 시작. 받은 코드: {}", code);
-
-        if (code == null || code.isBlank()) {
-            logger.error("❌ GitHub 인증 실패: code 값이 없습니다.");
-            throw new RuntimeException("GitHub 인증 실패: code 값이 없습니다.");
-        }
-
-        if (isCodeAlreadyUsed(code)) {
-            logger.error("❌ 이미 사용된 OAuth 코드: {}", code);
-            throw new RuntimeException("이미 사용된 OAuth 코드입니다.");
-        }
-
-        // GitHub에서 액세스 토큰 요청
-        String accessToken = fetchAccessTokenFromGitHub(code);
-
-        // 액세스 토큰을 이용하여 사용자 정보 요청
-        return fetchUserInfoFromGitHub(accessToken);
-    }
+    private final RestTemplate restTemplate = new RestTemplate();
 
     /**
      * GitHub에서 액세스 토큰 요청
      */
-    private String fetchAccessTokenFromGitHub(String code) {
-        logger.info("🔄 GitHub 액세스 토큰 요청 시작: code={}, client_id={}, redirect_uri={}", code, clientId, githubRedirectUri);
-
-        if (isCodeAlreadyUsed(code)) {
-            throw new RuntimeException("🚫 이미 사용된 OAuth code: " + code);
-        }
-
-        // 사용된 코드로 먼저 등록
-        markCodeAsUsed(code);
-
+    @Override
+    public String getAccessToken(String code) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         headers.set("Accept", "application/json");
@@ -87,105 +37,36 @@ public class GitHubOAuthProvider {
         tokenRequest.add("client_id", clientId);
         tokenRequest.add("client_secret", clientSecret);
         tokenRequest.add("code", code);
-        tokenRequest.add("redirect_uri", githubRedirectUri); // 추가
-
-//        Map<String, String> tokenRequest = Map.of(
-//                "client_id", clientId,
-//                "client_secret", clientSecret,
-//                "code", code
-//        );
+        tokenRequest.add("redirect_uri", redirectUri);
 
         HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(tokenRequest, headers);
 
-        try {
-            ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
-                    "https://github.com/login/oauth/access_token",
-                    HttpMethod.POST,
-                    requestEntity,
-                    new ParameterizedTypeReference<>() {});
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "https://github.com/login/oauth/access_token",
+                HttpMethod.POST,
+                requestEntity,
+                new ParameterizedTypeReference<>() {});
 
-            Map<String, Object> responseBody = response.getBody();
-
-            if (responseBody == null || !responseBody.containsKey("access_token")) {
-                logger.error("❌ GitHub 액세스 토큰 발급 실패: 응답={}", responseBody);
-                usedCodes.remove(code);
-                throw new RuntimeException("GitHub 액세스 토큰을 가져오지 못했습니다.");
-            }
-
-            if (responseBody.containsKey("error")) {
-                logger.error("❌ GitHub 액세스 토큰 발급 실패: 오류={}", responseBody);
-                usedCodes.remove(code);
-                throw new RuntimeException("GitHub 액세스 토큰 오류: " + responseBody.get("error_description"));
-            }
-
-            String accessToken = (String) responseBody.get("access_token");
-            logger.info("🔑 GitHub 액세스 토큰 발급 완료: {}", accessToken);
-            return accessToken;
-
-        } catch (RestClientException e) {
-            usedCodes.remove(code); // 요청 중 예외 발생 시 code 사용 취소
-            logger.error("❌ GitHub 액세스 토큰 요청 중 오류 발생: {}", e.getMessage(), e);
-            throw new RuntimeException("GitHub API 요청 중 오류 발생", e);
-        }
+        return (String) response.getBody().get("access_token");
     }
 
     /**
      * GitHub에서 사용자 정보 요청
      */
-    /**
-     * GitHub에서 사용자 정보 요청
-     */
-    private Map<String, Object> fetchUserInfoFromGitHub(String accessToken) {
+    @Override
+    public Map<String, Object> getUserInfo(String accessToken) {
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "Bearer " + accessToken);
         headers.set("Accept", "application/json");
 
-        // 헤더 확인 로그 추가
-        logger.info("🔍 GitHub API 요청 헤더: {}", headers);
-
         HttpEntity<String> requestEntity = new HttpEntity<>(headers);
 
-        try {
-            ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
-                    "https://api.github.com/user",
-                    HttpMethod.GET,
-                    requestEntity,
-                    new ParameterizedTypeReference<>() {});
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "https://api.github.com/user",
+                HttpMethod.GET,
+                requestEntity,
+                new ParameterizedTypeReference<>() {});
 
-            Map<String, Object> userInfo = response.getBody();
-
-            if (userInfo == null || userInfo.isEmpty()) {
-                logger.error("❌ GitHub 사용자 정보 조회 실패: 응답이 비어 있음");
-                throw new RuntimeException("GitHub 사용자 정보를 가져오지 못했습니다.");
-            }
-
-            // 불변성을 유지하기 위해 새로운 Map 객체 생성
-            Map<String, Object> userInfoWithToken = new HashMap<>(userInfo);
-            userInfoWithToken.put("access_token", accessToken);
-
-            logger.info("✅ GitHub 사용자 정보: {}", userInfoWithToken);
-            return userInfoWithToken;
-        } catch (RestClientException e) {
-            logger.error("❌ GitHub 사용자 정보 요청 실패: {}", e.getMessage(), e);
-            throw new RuntimeException("GitHub API 요청 중 오류 발생", e);
-        }
-    }
-
-    /**
-     * 이미 사용된 코드인지 확인
-     */
-    public boolean isCodeAlreadyUsed(String code) {
-        if (usedCodes.contains(code)) {
-            logger.warn("🚫 이미 사용된 OAuth code: {}", code);
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * 사용된 코드로 등록
-     */
-    private void markCodeAsUsed(String code) {
-        usedCodes.add(code);
+        return response.getBody();
     }
 }

--- a/src/main/java/com/goorm/team9/icontact/domain/sociallogin/security/provider/GoogleOAuthProvider.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/sociallogin/security/provider/GoogleOAuthProvider.java
@@ -1,74 +1,65 @@
-/**
- *  구글 로그인 구현
- */
-//package com.goorm.team9.icontact.domain.sociallogin.security.provider;
-//
-//import org.springframework.beans.factory.annotation.Value;
-//import org.springframework.core.ParameterizedTypeReference;
-//import org.springframework.http.HttpEntity;
-//import org.springframework.http.HttpHeaders;
-//import org.springframework.http.HttpMethod;
-//import org.springframework.http.MediaType;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.stereotype.Service;
-//import org.springframework.util.LinkedMultiValueMap;
-//import org.springframework.util.MultiValueMap;
-//import org.springframework.web.client.RestTemplate;
-//import java.util.Map;
-//
-//@Service
-//public class GoogleOAuthProvider implements OAuthProvider {
-//
-//    @Value("${GOOGLE_CLIENT_ID}")
-//    private String clientId;
-//
-//    @Value("${GOOGLE_CLIENT_SECRET}")
-//    private String clientSecret;
-//
-//    @Value("${GOOGLE_REDIRECT_URI}")
-//    private String redirectUri;
-//
-//    private final RestTemplate restTemplate = new RestTemplate();
-//
-//    @Override
-//    public Map<String, Object> getUserInfo(String code) {
-//        String accessToken = fetchAccessTokenFromGoogle(code);
-//        return fetchUserInfoFromGoogle(accessToken);
-//    }
-//
-//    private String fetchAccessTokenFromGoogle(String code) {
-//        HttpHeaders headers = new HttpHeaders();
-//        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-//        headers.set("Accept", "application/json");
-//
-//        MultiValueMap<String, String> tokenRequest = new LinkedMultiValueMap<>();
-//        tokenRequest.add("client_id", clientId);
-//        tokenRequest.add("client_secret", clientSecret);
-//        tokenRequest.add("code", code);
-//        tokenRequest.add("redirect_uri", redirectUri);
-//        tokenRequest.add("grant_type", "authorization_code");
-//
-//        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(tokenRequest, headers);
-//        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
-//                "https://oauth2.googleapis.com/token",
-//                HttpMethod.POST,
-//                requestEntity,
-//                new ParameterizedTypeReference<>() {});
-//
-//        return (String) response.getBody().get("access_token");
-//    }
-//
-//    private Map<String, Object> fetchUserInfoFromGoogle(String accessToken) {
-//        HttpHeaders headers = new HttpHeaders();
-//        headers.set("Authorization", "Bearer " + accessToken);
-//        headers.set("Accept", "application/json");
-//
-//        HttpEntity<String> requestEntity = new HttpEntity<>(headers);
-//        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
-//                "https://www.googleapis.com/oauth2/v3/userinfo", HttpMethod.GET, requestEntity,
-//                new ParameterizedTypeReference<>() {});
-//
-//        return response.getBody();
-//    }
-//}
-//
+package com.goorm.team9.icontact.domain.sociallogin.security.provider;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Service
+public class GoogleOAuthProvider implements OAuthProvider {
+
+    @Value("${GOOGLE_CLIENT_ID}")
+    private String clientId;
+
+    @Value("${GOOGLE_CLIENT_SECRET}")
+    private String clientSecret;
+
+    @Value("${GOOGLE_REDIRECT_URI}")
+    private String redirectUri;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Override
+    public String getAccessToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set("Accept", "application/json");
+
+        MultiValueMap<String, String> tokenRequest = new LinkedMultiValueMap<>();
+        tokenRequest.add("client_id", clientId);
+        tokenRequest.add("client_secret", clientSecret);
+        tokenRequest.add("code", code);
+        tokenRequest.add("redirect_uri", redirectUri);
+        tokenRequest.add("grant_type", "authorization_code");
+
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(tokenRequest, headers);
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "https://oauth2.googleapis.com/token",
+                HttpMethod.POST,
+                requestEntity,
+                new ParameterizedTypeReference<>() {});
+
+        return (String) response.getBody().get("access_token");
+    }
+
+    @Override
+    public Map<String, Object> getUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+        headers.set("Accept", "application/json");
+
+        HttpEntity<String> requestEntity = new HttpEntity<>(headers);
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "https://www.googleapis.com/oauth2/v3/userinfo",
+                HttpMethod.GET,
+                requestEntity,
+                new ParameterizedTypeReference<>() {});
+
+        return response.getBody();
+    }
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/sociallogin/security/provider/KakaoOAuthProvider.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/sociallogin/security/provider/KakaoOAuthProvider.java
@@ -1,74 +1,97 @@
 /**
  *  카카오 로그인 구현
  */
-//package com.goorm.team9.icontact.domain.sociallogin.security.provider;
-//
-//import org.springframework.beans.factory.annotation.Value;
-//import org.springframework.core.ParameterizedTypeReference;
-//import org.springframework.http.HttpEntity;
-//import org.springframework.http.HttpHeaders;
-//import org.springframework.http.HttpMethod;
-//import org.springframework.http.MediaType;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.stereotype.Service;
-//import org.springframework.util.LinkedMultiValueMap;
-//import org.springframework.util.MultiValueMap;
-//import org.springframework.web.client.RestTemplate;
-//import java.util.Map;
-//
-//@Service
-//public class KakaoOAuthProvider implements OAuthProvider {
-//
-//    @Value("${KAKAO_CLIENT_ID}")
-//    private String clientId;
-//
-//    @Value("${KAKAO_CLIENT_SECRET}")
-//    private String clientSecret;
-//
-//    @Value("${KAKAO_REDIRECT_URI}")
-//    private String redirectUri;
-//
-//    private final RestTemplate restTemplate = new RestTemplate();
-//
-//    @Override
-//    public Map<String, Object> getUserInfo(String code) {
-//        String accessToken = fetchAccessTokenFromKakao(code);
-//        return fetchUserInfoFromKakao(accessToken);
-//    }
-//
-//    private String fetchAccessTokenFromKakao(String code) {
-//        HttpHeaders headers = new HttpHeaders();
-//        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-//        headers.set("Accept", "application/json");
-//
-//        MultiValueMap<String, String> tokenRequest = new LinkedMultiValueMap<>();
-//        tokenRequest.add("client_id", clientId);
-//        tokenRequest.add("client_secret", clientSecret);
-//        tokenRequest.add("code", code);
-//        tokenRequest.add("redirect_uri", redirectUri);
-//        tokenRequest.add("grant_type", "authorization_code");
-//
-//        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(tokenRequest, headers);
-//        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
-//                "https://kauth.kakao.com/oauth/token",
-//                HttpMethod.POST,
-//                requestEntity,
-//                new ParameterizedTypeReference<>() {});
-//
-//        return (String) response.getBody().get("access_token");
-//    }
-//
-//    private Map<String, Object> fetchUserInfoFromKakao(String accessToken) {
-//        HttpHeaders headers = new HttpHeaders();
-//        headers.set("Authorization", "Bearer " + accessToken);
-//        headers.set("Accept", "application/json");
-//
-//        HttpEntity<String> requestEntity = new HttpEntity<>(headers);
-//        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
-//                "https://kapi.kakao.com/v2/user/me", HttpMethod.GET, requestEntity,
-//                new ParameterizedTypeReference<>() {});
-//
-//        return response.getBody();
-//    }
-//}
+package com.goorm.team9.icontact.domain.sociallogin.security.provider;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import java.util.Map;
+
+@Service
+public class KakaoOAuthProvider implements OAuthProvider {
+
+    @Value("${KAKAO_CLIENT_ID}")
+    private String clientId;
+
+    @Value("${KAKAO_CLIENT_SECRET}")
+    private String clientSecret;
+
+    @Value("${KAKAO_REDIRECT_URI}")
+    private String kakaoRedirectUri;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Override
+    public String getAccessToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set("Accept", "application/json");
+
+        MultiValueMap<String, String> tokenRequest = new LinkedMultiValueMap<>();
+        tokenRequest.add("grant_type", "authorization_code");
+        tokenRequest.add("client_id", clientId);
+        tokenRequest.add("client_secret", clientSecret);
+        tokenRequest.add("redirect_uri", kakaoRedirectUri);
+        tokenRequest.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(tokenRequest, headers);
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                requestEntity,
+                new ParameterizedTypeReference<>() {});
+
+        return (String) response.getBody().get("access_token");
+    }
+
+    @Override
+    public Map<String, Object> getUserInfo(String code) {
+        String accessToken = fetchAccessTokenFromKakao(code);
+        return fetchUserInfoFromKakao(accessToken);
+    }
+
+    private String fetchAccessTokenFromKakao(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set("Accept", "application/json");
+
+        MultiValueMap<String, String> tokenRequest = new LinkedMultiValueMap<>();
+        tokenRequest.add("client_id", clientId);
+        tokenRequest.add("client_secret", clientSecret);
+        tokenRequest.add("code", code);
+        tokenRequest.add("redirect_uri", kakaoRedirectUri);
+        tokenRequest.add("grant_type", "authorization_code");
+
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(tokenRequest, headers);
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                requestEntity,
+                new ParameterizedTypeReference<>() {});
+
+        return (String) response.getBody().get("access_token");
+    }
+
+    private Map<String, Object> fetchUserInfoFromKakao(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+        headers.set("Accept", "application/json");
+
+        HttpEntity<String> requestEntity = new HttpEntity<>(headers);
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "https://kapi.kakao.com/v2/user/me", HttpMethod.GET, requestEntity,
+                new ParameterizedTypeReference<>() {});
+
+        return response.getBody();
+    }
+}
 

--- a/src/main/java/com/goorm/team9/icontact/domain/sociallogin/security/provider/OAuthProvider.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/sociallogin/security/provider/OAuthProvider.java
@@ -1,10 +1,11 @@
 /**
  *  getUserInfo 이 부분을 나중에 이 파일로 옮겨주기!!!
  */
-//package com.goorm.team9.icontact.domain.sociallogin.security.provider;
-//
-//import java.util.Map;
-//
-//public interface OAuthProvider {
-//    Map<String, Object> getUserInfo(String code);
-//}
+package com.goorm.team9.icontact.domain.sociallogin.security.provider;
+
+import java.util.Map;
+
+public interface OAuthProvider {
+    String getAccessToken(String code);  // 액세스 토큰을 가져오는 메서드
+    Map<String, Object> getUserInfo(String accessToken);  // 유저 정보를 가져오는 메서드
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/sociallogin/security/provider/OAuthProviderFactory.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/sociallogin/security/provider/OAuthProviderFactory.java
@@ -1,25 +1,25 @@
 /**
  *  소셜 로그인 전략을 선택하는 팩토리!
  */
-//package com.goorm.team9.icontact.domain.sociallogin.security.provider;
-//
-//import java.util.List;
-//import java.util.Map;
-//import java.util.stream.Collectors;
-//import org.springframework.stereotype.Component;
-//
-//@Component
-//public class OAuthProviderFactory {
-//    private final Map<String, OAuthProvider> providers;
-//
-//    public OAuthProviderFactory(List<OAuthProvider> providerList) {
-//        this.providers = providerList.stream().collect(Collectors.toMap(
-//                provider -> provider.getClass().getSimpleName().replace("OAuthProvider", "").toLowerCase(),
-//                provider -> provider
-//        ));
-//    }
-//
-//    public OAuthProvider getProvider(String providerName) {
-//        return providers.get(providerName.toLowerCase());
-//    }
-//}
+package com.goorm.team9.icontact.domain.sociallogin.security.provider;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OAuthProviderFactory {
+    private final Map<String, OAuthProvider> providers;
+
+    public OAuthProviderFactory(List<OAuthProvider> providerList) {
+        this.providers = providerList.stream().collect(Collectors.toMap(
+                provider -> provider.getClass().getSimpleName().replace("OAuthProvider", "").toLowerCase(),
+                provider -> provider
+        ));
+    }
+
+    public OAuthProvider getProvider(String providerName) {
+        return providers.get(providerName.toLowerCase());
+    }
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/sociallogin/service/AuthService.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/sociallogin/service/AuthService.java
@@ -41,9 +41,9 @@ public class AuthService {
      * @param code GitHub에서 발급한 인증 코드
      * @return JWT 토큰
      */
-    public String loginWithGithub(String code) {
+    public String loginWithGithub(String provider, String code) {
         // OAuthService에서 GitHub 인증 및 사용자 정보 저장
-        String email = oAuthService.authenticateWithGithub(code);
+        String email = oAuthService.authenticateWithGithub(provider, code);
 
         // JWT 발급
         String jwtToken = jwtTokenProvider.createToken(email);

--- a/src/main/java/com/goorm/team9/icontact/domain/sociallogin/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/sociallogin/service/CustomOAuth2UserService.java
@@ -9,13 +9,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
-import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -28,7 +26,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final OAuthProviderFactory providerFactory;
     private final JwtTokenProvider jwtTokenProvider;
-    private static final Logger logger = LoggerFactory.getLogger(CustomOAuth2UserService.class);
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) {

--- a/src/main/java/com/goorm/team9/icontact/domain/sociallogin/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/sociallogin/service/CustomOAuth2UserService.java
@@ -1,7 +1,8 @@
 package com.goorm.team9.icontact.domain.sociallogin.service;
 
 import com.goorm.team9.icontact.domain.sociallogin.security.jwt.JwtTokenProvider;
-import com.goorm.team9.icontact.domain.sociallogin.security.provider.GitHubOAuthProvider;
+import com.goorm.team9.icontact.domain.sociallogin.security.provider.OAuthProvider;
+import com.goorm.team9.icontact.domain.sociallogin.security.provider.OAuthProviderFactory;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,49 +26,26 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
-    private final OAuthService oAuthService;
+    private final OAuthProviderFactory providerFactory;
     private final JwtTokenProvider jwtTokenProvider;
-    private final GitHubOAuthProvider gitHubOAuthProvider;
     private static final Logger logger = LoggerFactory.getLogger(CustomOAuth2UserService.class);
 
-    /**
-     * OAuth2 로그인 후 사용자 정보를 가져오고 JWT 발급
-     *
-     * @param userRequest OAuth2 로그인 요청 정보
-     * @return OAuth2User (JWT 포함)
-     */
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) {
-        OAuth2AccessToken accessToken = userRequest.getAccessToken();
-        String accessTokenValue = accessToken.getTokenValue();
+        String provider = userRequest.getClientRegistration().getRegistrationId(); // "github", "google", "kakao"
+        String code = userRequest.getAccessToken().getTokenValue();
 
-        // OAuth 요청이 반복되는지 체크
-        if (gitHubOAuthProvider.isCodeAlreadyUsed(accessTokenValue)) { // 정상 작동
-            throw new RuntimeException("이미 사용된 OAuth 인증 코드입니다.");
+        OAuthProvider oAuthProvider = providerFactory.getProvider(provider);
+        if (oAuthProvider == null) {
+            throw new RuntimeException("지원하지 않는 OAuth 제공자: " + provider);
         }
 
-        Map<String, Object> githubUserInfo = gitHubOAuthProvider.getUserInfo(accessToken.getTokenValue());
+        String accessToken = oAuthProvider.getAccessToken(code);
+        Map<String, Object> userInfo = oAuthProvider.getUserInfo(accessToken);
 
-        String provider = userRequest.getClientRegistration().getRegistrationId();
-        String oauthUserId = githubUserInfo.get("id").toString();
-        String email = (String) githubUserInfo.getOrDefault("email", "no-email");
-        String nickname = (String) githubUserInfo.get("login");
+        String jwtToken = jwtTokenProvider.createToken((String) userInfo.get("email"));
+        userInfo.put("jwtToken", jwtToken);
 
-        // OAuth 사용자 정보 저장 (OAuthService의 메서드 호출)
-        oAuthService.saveOrUpdateUser(provider, oauthUserId, email, nickname, accessTokenValue); // accessToken 추가
-
-        // JWT 발급
-        String jwtToken = jwtTokenProvider.createToken(email);
-
-        // 사용자 정보 반환 (JWT 포함)
-        Map<String, Object> attributes = new HashMap<>(githubUserInfo);
-        attributes.put("jwtToken", jwtToken);
-
-        logger.info("✅ OAuth 로그인 완료: {}, JWT 발급됨", email);
-
-        return new DefaultOAuth2User(
-                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
-                attributes, "id"
-        );
+        return new DefaultOAuth2User(Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")), userInfo, "email");
     }
 }

--- a/src/main/java/com/goorm/team9/icontact/domain/sociallogin/service/OAuthService.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/sociallogin/service/OAuthService.java
@@ -4,7 +4,8 @@ import com.goorm.team9.icontact.domain.client.entity.ClientEntity;
 import com.goorm.team9.icontact.domain.client.repository.ClientRepository;
 import com.goorm.team9.icontact.domain.sociallogin.domain.OAuth;
 import com.goorm.team9.icontact.domain.sociallogin.repository.OAuthRepository;
-import com.goorm.team9.icontact.domain.sociallogin.security.provider.GitHubOAuthProvider;
+import com.goorm.team9.icontact.domain.sociallogin.security.provider.OAuthProvider;
+import com.goorm.team9.icontact.domain.sociallogin.security.provider.OAuthProviderFactory;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,34 +35,29 @@ public class OAuthService {
 
     private final ClientRepository clientRepository;
     private final OAuthRepository oauthRepository;
-    private final GitHubOAuthProvider gitHubOAuthProvider;
+    private final OAuthProviderFactory providerFactory;
     private static final Logger logger = LoggerFactory.getLogger(OAuthService.class);
 
     /**
-     * GitHub OAuth 로그인 처리
-     * - GitHub에서 사용자 정보를 가져오고 JWT 발급을 담당
+     * OAuth 로그인 처리
+     * - 사용자 정보를 가져오고 JWT 발급을 담당
      *
-     * @param code GitHub에서 발급한 인증 코드
+     * @param code  발급한 인증 코드
      * @return JWT 토큰 (이후 AuthService에서 사용)
      */
-    public String authenticateWithGithub(String code) {
-        var githubUserInfo = gitHubOAuthProvider.getUserInfo(code);
-
-        // access_token 검증
-        if (!githubUserInfo.containsKey("access_token")) {
-            logger.error("❌ OAuthService: access_token 없음!");
-            throw new RuntimeException("GitHub 액세스 토큰 없음!");
+    public String authenticateWithGithub(String provider, String code) {
+        OAuthProvider oAuthProvider = providerFactory.getProvider(provider);
+        if (oAuthProvider == null) {
+            throw new IllegalArgumentException("지원하지 않는 OAuth 제공자: " + provider);
         }
-        String accessToken = githubUserInfo.get("access_token").toString();
-        logger.info("🔑 OAuthService에서 받은 액세스 토큰: {}", accessToken);
 
-        String provider = "github";
-        String oauthUserId = githubUserInfo.get("id").toString();
-//        String accessToken = githubUserInfo.get("access_token").toString(); // 토큰 가져오기
-        String email = (String) githubUserInfo.getOrDefault("email", "no-email");
-        String nickname = (String) githubUserInfo.get("login");
+        String accessToken = oAuthProvider.getAccessToken(code);
+        Map<String, Object> userInfo = oAuthProvider.getUserInfo(accessToken);
 
-        // GitHub API에서 이메일이 없는 경우 fetchGitHubEmail() 호출
+        String oauthUserId = userInfo.get("id").toString();
+        String email = (String) userInfo.getOrDefault("email", "no-email");
+        String nickname = (String) userInfo.getOrDefault("login", "unknown");
+
         if ("no-email".equals(email) || email == null) {
             email = fetchGitHubEmail(accessToken);
         }
@@ -69,8 +65,8 @@ public class OAuthService {
         // 사용자 정보 저장 또는 업데이트
         saveOrUpdateUser(provider, oauthUserId, email, nickname, accessToken);
 
-        logger.info("✅ GitHub 로그인 완료: {}", email);
-        return email; // AuthService에서 JWT 생성
+        logger.info("✅ {} 로그인 완료: {}", provider, email);
+        return email;
     }
 
     /**
@@ -147,5 +143,4 @@ public class OAuthService {
             return null;
         }
     }
-
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,18 +60,25 @@ spring:
             - user:email
             - read:user
             redirect-uri: ${GITHUB_REDIRECT_URI}
-#          google:
-#            client-id: your-google-client-id
-#            client-secret: your-google-client-secret
-#            scope: profile, email
-#          kakao:
-#            client-id: your-kakao-client-id
-#            client-secret: your-kakao-client-secret
-#            client-authentication-method: POST
-#            authorization-grant-type: authorization_code
-#            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
-#            scope: profile_nickname, account_email
-#            client-name: Kakao
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            scope: profile, email
+            redirect-uri: ${GOOGLE_REDIRECT_URI}
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            client-authentication-method: POST
+            authorization-grant-type: authorization_code
+            redirect-uri: ${KAKAO_REDIRECT_URI}
+            scope: account_email
+            client-name: Kakao
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
 #          naver:
 #            client-id: your-naver-client-id
 #            client-secret: your-naver-client-secret


### PR DESCRIPTION
## 📋 Summary

> - closes #31

**소셜 로그인 : 구글 & 카카오**


## ✅ Tasks

- 소셜 로그인 : 구글 구현
- 소셜 로그인 : 카카오 구현

## ✏️ To Reviewer

.env 추가와 와 application.yml 변경 되어서 관련 내용 공유하겠습니다!

## 📷 Screenshot
<img width="500" alt="스크린샷 2025-03-17 오전 10 15 47" src="https://github.com/user-attachments/assets/f3d2c1a8-69c2-447c-8e06-59e037837bd8" />

<img width="485" alt="스크린샷 2025-03-17 오전 10 15 58" src="https://github.com/user-attachments/assets/9ed56128-d196-4ed9-b79e-8a362407cd83" />
