### PR TITLE
[#51] 컨퍼런스와 강연 내용을 관리하는 기능 구현

### DIFF
--- a/src/main/java/com/goorm/team9/icontact/common/error/LectureErrorCode.java
+++ b/src/main/java/com/goorm/team9/icontact/common/error/LectureErrorCode.java
@@ -1,0 +1,16 @@
+package com.goorm.team9.icontact.common.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum LectureErrorCode implements ErrorCodeInterface {
+
+    CONFERENCE_NOT_FOUND(404, 2001, "해당 컨퍼런스를 찾을 수 없습니다.");
+
+    private final Integer httpStatusCode;
+    private final Integer errorCode;
+    private final String description;
+}
+

--- a/src/main/java/com/goorm/team9/icontact/config/security/SecurityConfig.java
+++ b/src/main/java/com/goorm/team9/icontact/config/security/SecurityConfig.java
@@ -53,8 +53,9 @@ public class SecurityConfig {
                             "http://3.34.165.63:8080",
                             "http://43.201.245.222:8080",
                             "https://www.i-contacts.link",
-                            "*"));
-                    config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "FETCH", "OPTIONS"));
+                            "http://localhost:5173"
+                    ));
+                    config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
                     config.setAllowedHeaders(List.of("*"));
                     config.setExposedHeaders(List.of("Authorization", "Content-Type"));
                     return config;

--- a/src/main/java/com/goorm/team9/icontact/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/goorm/team9/icontact/config/swagger/SwaggerConfig.java
@@ -1,8 +1,8 @@
 package com.goorm.team9.icontact.config.swagger;
 
-import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,8 +27,30 @@ public class SwaggerConfig {
 
     private Info apiInfo() {
         return new Info()
-                .title("Team-9 / I-Contact")
-                .description("9팀 I-Contact API 명세서")
-                .version("1.0.0");
+                .title("Team-9 / 👀 I-Contact")
+                .version("1.0.0")
+                .description(
+                        """
+                        ## 🚀 I-Contact API 명세서
+                        ### 🎨 디자이너
+                        이준, 황소희
+                        \n\n
+                        ### 🖥️ 프론트엔드
+                        안주현, 윤가은, 유지수
+                        \n\n
+                        ### 🌐 백엔드
+                        이지은, 이서원, 성현아, 이정훈
+                        \n\n
+                        ### 🔗 링크
+                        📌 [I-Contact-Web](https://www.i-contacts.link)
+                        \n\n
+                        📌 [GitHub](https://github.com/DeepDive-Final-Project)
+                        \n\n
+                        📌 [Notion](https://www.notion.so/I-Contact-Team-Project-1a47fd02709c8034a6f0f43be421f718)
+                        \n\n
+                        📌 [Jira](https://qweqwerty12321-1740141206278.atlassian.net/jira/software/projects/ICT/pages)
+                        """
+                );
     }
+
 }

--- a/src/main/java/com/goorm/team9/icontact/domain/conference/controller/ConferenceController.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/conference/controller/ConferenceController.java
@@ -1,0 +1,40 @@
+package com.goorm.team9.icontact.domain.conference.controller;
+
+import com.goorm.team9.icontact.domain.conference.dto.response.ConferenceResponseDTO;
+import com.goorm.team9.icontact.domain.conference.enums.Day;
+import com.goorm.team9.icontact.domain.conference.service.ConferenceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/conferences")
+@RequiredArgsConstructor
+@Tag(name = "Conference API", description = "컨퍼런스 관련 API")
+public class ConferenceController {
+
+    private final ConferenceService conferenceService;
+
+    @PostMapping
+    @Operation(summary = "컨퍼런스 등록", description = "새로운 컨퍼런스를 등록합니다.")
+    public ResponseEntity<ConferenceResponseDTO> createConference(
+            @RequestParam String name,
+            @RequestParam Day day
+    ) {
+        return ResponseEntity.ok(conferenceService.createConference(name, day));
+    }
+
+    @GetMapping("/day")
+    @Operation(summary = "특정 일자의 컨퍼런스 조회", description = "DAY_1 ~ DAY_5 중 선택")
+    public ResponseEntity<List<ConferenceResponseDTO>> getConferencesByDay(
+            @RequestParam Day day
+    ) {
+        return ResponseEntity.ok(conferenceService.getConferencesByDay(day));
+    }
+}
+
+

--- a/src/main/java/com/goorm/team9/icontact/domain/conference/dto/request/ConferenceRequestDTO.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/conference/dto/request/ConferenceRequestDTO.java
@@ -1,0 +1,15 @@
+package com.goorm.team9.icontact.domain.conference.dto.request;
+
+import com.goorm.team9.icontact.domain.conference.enums.Day;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ConferenceRequestDTO {
+    private String name;
+    private Day day;
+}
+
+
+

--- a/src/main/java/com/goorm/team9/icontact/domain/conference/dto/response/ConferenceResponseDTO.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/conference/dto/response/ConferenceResponseDTO.java
@@ -1,0 +1,23 @@
+package com.goorm.team9.icontact.domain.conference.dto.response;
+
+import com.goorm.team9.icontact.domain.conference.entity.ConferenceEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ConferenceResponseDTO {
+    private Long id;
+    private String name;
+    private String day;
+
+    public ConferenceResponseDTO(ConferenceEntity entity) {
+        this.id = entity.getId();
+        this.name = entity.getName();
+        this.day = entity.getDay().getDescription();
+    }
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/conference/entity/ConferenceEntity.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/conference/entity/ConferenceEntity.java
@@ -1,0 +1,32 @@
+package com.goorm.team9.icontact.domain.conference.entity;
+
+import com.goorm.team9.icontact.domain.conference.enums.Day;
+import com.goorm.team9.icontact.domain.lecture.entity.LectureEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "conference")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ConferenceEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Day day;
+
+    @OneToMany(mappedBy = "conference", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<LectureEntity> lectures = new ArrayList<>();
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/conference/enums/Day.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/conference/enums/Day.java
@@ -1,0 +1,20 @@
+package com.goorm.team9.icontact.domain.conference.enums;
+
+import com.goorm.team9.icontact.domain.common.EnumWithDescription;
+import lombok.Getter;
+
+@Getter
+public enum Day implements EnumWithDescription {
+
+    DAY_1("컨퍼런스 1일차"),
+    DAY_2("컨퍼런스 2일차"),
+    DAY_3("컨퍼런스 3일차"),
+    DAY_4("컨퍼런스 4일차"),
+    DAY_5("컨퍼런스 5일차");
+
+    private final String description;
+
+    Day (String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/conference/repository/ConferenceRepository.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/conference/repository/ConferenceRepository.java
@@ -1,0 +1,11 @@
+package com.goorm.team9.icontact.domain.conference.repository;
+
+import com.goorm.team9.icontact.domain.conference.entity.ConferenceEntity;
+import com.goorm.team9.icontact.domain.conference.enums.Day;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ConferenceRepository extends JpaRepository<ConferenceEntity, Long> {
+    List<ConferenceEntity> findByDay(Day day);
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/conference/service/ConferenceService.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/conference/service/ConferenceService.java
@@ -1,0 +1,35 @@
+package com.goorm.team9.icontact.domain.conference.service;
+
+import com.goorm.team9.icontact.domain.conference.dto.request.ConferenceRequestDTO;
+import com.goorm.team9.icontact.domain.conference.dto.response.ConferenceResponseDTO;
+import com.goorm.team9.icontact.domain.conference.entity.ConferenceEntity;
+import com.goorm.team9.icontact.domain.conference.enums.Day;
+import com.goorm.team9.icontact.domain.conference.repository.ConferenceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ConferenceService {
+
+    private final ConferenceRepository conferenceRepository;
+
+    public ConferenceResponseDTO createConference(String name, Day day) {
+        ConferenceEntity conference = ConferenceEntity.builder()
+                .name(name)
+                .day(day)
+                .build();
+
+        conferenceRepository.save(conference);
+        return new ConferenceResponseDTO(conference);
+    }
+
+    public List<ConferenceResponseDTO> getConferencesByDay(Day day) {
+        return conferenceRepository.findByDay(day).stream()
+                .map(conf -> new ConferenceResponseDTO(conf.getId(), conf.getName(), conf.getDay().getDescription()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/lecture/controller/LectureController.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/lecture/controller/LectureController.java
@@ -1,0 +1,41 @@
+package com.goorm.team9.icontact.domain.lecture.controller;
+
+import com.goorm.team9.icontact.domain.lecture.dto.request.LectureRequestDTO;
+import com.goorm.team9.icontact.domain.lecture.dto.response.LectureResponseDTO;
+import com.goorm.team9.icontact.domain.lecture.service.LectureService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/lectures")
+@RequiredArgsConstructor
+@Tag(name = "Lecture API", description = "강의 등록 및 조회 API")
+public class LectureController {
+
+    private final LectureService lectureService;
+
+    @PostMapping
+    @Operation(summary = "강의 등록", description = "컨퍼런스에 강의를 등록합니다.")
+    public ResponseEntity<LectureResponseDTO> createLecture(
+            @RequestParam String title,
+            @RequestParam String lecturer,
+            @RequestParam String openTime,  // 형식: HH:mm
+            @RequestParam String closeTime, // 형식: HH:mm
+            @RequestParam Long conferenceId
+    ) {
+        return ResponseEntity.ok(lectureService.createLecture(title, lecturer, openTime, closeTime, conferenceId));
+    }
+
+    @GetMapping("/conference")
+    @Operation(summary = "컨퍼런스 강의 목록 조회", description = "특정 컨퍼런스의 모든 강의 목록을 조회합니다.")
+    public ResponseEntity<List<LectureResponseDTO>> getLecturesByConference(
+            @RequestParam Long conferenceId
+    ) {
+        return ResponseEntity.ok(lectureService.getLecturesByConference(conferenceId));
+    }
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/lecture/dto/request/LectureRequestDTO.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/lecture/dto/request/LectureRequestDTO.java
@@ -1,0 +1,15 @@
+package com.goorm.team9.icontact.domain.lecture.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LectureRequestDTO {
+    private String title;
+    private String lecturer;
+    private String openTime;
+    private String closeTime;
+    private Long conferenceId;
+}
+

--- a/src/main/java/com/goorm/team9/icontact/domain/lecture/dto/response/LectureResponseDTO.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/lecture/dto/response/LectureResponseDTO.java
@@ -1,0 +1,35 @@
+package com.goorm.team9.icontact.domain.lecture.dto.response;
+
+import com.goorm.team9.icontact.domain.lecture.entity.LectureEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class LectureResponseDTO {
+    private Long id;
+    private String title;
+    private String lecturer;
+    private String openTime;
+    private String closeTime;
+    private String conferenceName;
+    private String conferenceDay;
+
+    // LectureResponseDTO.java
+    public LectureResponseDTO(LectureEntity entity) {
+        this.id = entity.getId();
+        this.title = entity.getTitle();
+        this.lecturer = entity.getLecturer();
+        this.openTime = entity.getOpenTime().toString();
+        this.closeTime = entity.getCloseTime().toString();
+        this.conferenceName = entity.getConference().getName();
+        this.conferenceDay = entity.getConference().getDay().getDescription();
+    }
+
+}
+
+

--- a/src/main/java/com/goorm/team9/icontact/domain/lecture/entity/LectureEntity.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/lecture/entity/LectureEntity.java
@@ -1,0 +1,37 @@
+package com.goorm.team9.icontact.domain.lecture.entity;
+
+import com.goorm.team9.icontact.domain.conference.entity.ConferenceEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "lecture")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LectureEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String lecturer;
+
+    @Column(nullable = false)
+    private LocalTime openTime;
+
+    @Column(nullable = false)
+    private LocalTime closeTime;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "conference_id")
+    private ConferenceEntity conference;
+}
+

--- a/src/main/java/com/goorm/team9/icontact/domain/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/lecture/repository/LectureRepository.java
@@ -1,0 +1,11 @@
+package com.goorm.team9.icontact.domain.lecture.repository;
+
+import com.goorm.team9.icontact.domain.lecture.entity.LectureEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface LectureRepository extends JpaRepository<LectureEntity, Long> {
+
+    List<LectureEntity> findByConferenceId(Long conferenceId);
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/lecture/service/LectureService.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/lecture/service/LectureService.java
@@ -1,0 +1,60 @@
+package com.goorm.team9.icontact.domain.lecture.service;
+
+import com.goorm.team9.icontact.common.error.LectureErrorCode;
+import com.goorm.team9.icontact.common.exception.CustomException;
+import com.goorm.team9.icontact.domain.conference.entity.ConferenceEntity;
+import com.goorm.team9.icontact.domain.conference.repository.ConferenceRepository;
+import com.goorm.team9.icontact.domain.lecture.dto.request.LectureRequestDTO;
+import com.goorm.team9.icontact.domain.lecture.dto.response.LectureResponseDTO;
+import com.goorm.team9.icontact.domain.lecture.entity.LectureEntity;
+import com.goorm.team9.icontact.domain.lecture.repository.LectureRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class LectureService {
+
+    private final LectureRepository lectureRepository;
+    private final ConferenceRepository conferenceRepository;
+
+    public LectureResponseDTO createLecture(String title, String lecturer, String openTime, String closeTime, Long conferenceId) {
+        LocalTime open = LocalTime.parse(openTime);
+        LocalTime close = LocalTime.parse(closeTime);
+
+        ConferenceEntity conference = conferenceRepository.findById(conferenceId)
+                .orElseThrow(() -> new CustomException(LectureErrorCode.CONFERENCE_NOT_FOUND));
+
+        LectureEntity lecture = LectureEntity.builder()
+                .title(title)
+                .lecturer(lecturer)
+                .openTime(open)
+                .closeTime(close)
+                .conference(conference)
+                .build();
+
+        lectureRepository.save(lecture);
+        return new LectureResponseDTO(lecture);
+    }
+
+
+    public List<LectureResponseDTO> getLecturesByConference(Long conferenceId) {
+        List<LectureEntity> lectures = lectureRepository.findByConferenceId(conferenceId);
+        return lectures.stream()
+                .map(lec -> new LectureResponseDTO(
+                        lec.getId(),
+                        lec.getTitle(),
+                        lec.getLecturer(),
+                        lec.getOpenTime().toString(),
+                        lec.getCloseTime().toString(),
+                        lec.getConference().getName(),
+                        lec.getConference().getDay().getDescription()
+                ))
+                .collect(Collectors.toList());
+    }
+}
+


### PR DESCRIPTION
## 📋 Summary

> - closes #51 
> - **컨퍼런스와 강연 내용을 관리하는 기능을 구현합니다.**


## ✅ Tasks

> - 컨퍼런스 등록, 출력 기능 추가
> - 강연의 등록, 출력 기능 추가
> - 각 가능의 수정 및 삭제 기능은 추후 추가 예정ㅇ

## ✏️ To Reviewer

해당 기능 PR & Merge 이후 데이터 요청 형식을 RequestBody로 수정하겠습니다.
전체 코드를 살펴보고 Param으로 된 부분이 있으면 해당 기능 구현하신 개발자분께 하락 받고 수정하겠습니다.

## 📷 Screenshot

<img width="966" alt="스크린샷 2025-03-18 오후 1 28 30" src="https://github.com/user-attachments/assets/687aedee-0bfc-4ffe-a6a2-71ca85b21e17" />
<img width="966" alt="스크린샷 2025-03-18 오후 1 28 38" src="https://github.com/user-attachments/assets/966916e2-acc7-41a6-b80b-fc364c021fc8" />