### PR TITLE
[#57] 채팅 api 수정 및 에러 해결

### DIFF
--- a/src/main/java/com/goorm/team9/icontact/domain/block/controller/BlockController.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/block/controller/BlockController.java
@@ -1,14 +1,13 @@
 package com.goorm.team9.icontact.domain.block.controller;
 
+import com.goorm.team9.icontact.domain.block.dto.BlockRequestDto;
+import com.goorm.team9.icontact.domain.block.dto.UnblockRequesetDto;
 import com.goorm.team9.icontact.domain.block.service.BlockService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
 
 @Tag(name = "Block API", description = "차단 및 차단 해제 API 입니다.")
 @RestController
@@ -20,27 +19,15 @@ public class BlockController {
 
     @Operation(summary = "사용자 차단 API", description = "사용자를 차단합니다.")
     @PostMapping("/block")
-    public ResponseEntity<String> blockUser(
-            @RequestBody
-            @Schema(example = "{\"blockerNickname\": \"userA\", \"blockedNickname\": \"userB\"}")
-            Map<String, String> request) {
-        String blockerNickname = request.get("blockerNickname");
-        String blockedNickname = request.get("blockedNickname");
-
-        blockService.blockUser(blockerNickname, blockedNickname);
+    public ResponseEntity<String> blockUser(@RequestBody BlockRequestDto request) {
+        blockService.blockUser(request.getBlockerNickname(), request.getBlockedNickname());
         return ResponseEntity.ok("사용자가 차단되었습니다.");
     }
 
     @Operation(summary = "사용자 차단 해제 API", description = "사용자를 차단 해제합니다.")
     @PostMapping("/unblock")
-    public ResponseEntity<String> unblockUser(
-            @RequestBody
-            @Schema(example = "{\"blockerNickname\": \"userA\", \"blockedNickname\": \"userB\"}")
-            Map<String, String> request) {
-        String blockerNickname = request.get("blockerNickname");
-        String blockedNickname = request.get("blockedNickname");
-
-        blockService.unblockUser(blockerNickname, blockedNickname);
+    public ResponseEntity<String> unblockUser(@RequestBody UnblockRequesetDto requeset) {
+        blockService.unblockUser(requeset.getBlockerNickname(), requeset.getBlockedNickname());
         return ResponseEntity.ok("사용자 차단이 해제되었습니다.");
     }
 }

--- a/src/main/java/com/goorm/team9/icontact/domain/block/controller/BlockController.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/block/controller/BlockController.java
@@ -3,12 +3,12 @@ package com.goorm.team9.icontact.domain.block.controller;
 import com.goorm.team9.icontact.domain.block.service.BlockService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @Tag(name = "Block API", description = "차단 및 차단 해제 API 입니다.")
 @RestController
@@ -20,14 +20,26 @@ public class BlockController {
 
     @Operation(summary = "사용자 차단 API", description = "사용자를 차단합니다.")
     @PostMapping("/block")
-    public ResponseEntity<String> blockUser(@RequestParam String blockerNickname, @RequestParam String blockedNickname) {
+    public ResponseEntity<String> blockUser(
+            @RequestBody
+            @Schema(example = "{\"blockerNickname\": \"userA\", \"blockedNickname\": \"userB\"}")
+            Map<String, String> request) {
+        String blockerNickname = request.get("blockerNickname");
+        String blockedNickname = request.get("blockedNickname");
+
         blockService.blockUser(blockerNickname, blockedNickname);
         return ResponseEntity.ok("사용자가 차단되었습니다.");
     }
 
     @Operation(summary = "사용자 차단 해제 API", description = "사용자를 차단 해제합니다.")
     @PostMapping("/unblock")
-    public ResponseEntity<String> unblockUser(@RequestParam String blockerNickname, @RequestParam String blockedNickname) {
+    public ResponseEntity<String> unblockUser(
+            @RequestBody
+            @Schema(example = "{\"blockerNickname\": \"userA\", \"blockedNickname\": \"userB\"}")
+            Map<String, String> request) {
+        String blockerNickname = request.get("blockerNickname");
+        String blockedNickname = request.get("blockedNickname");
+
         blockService.unblockUser(blockerNickname, blockedNickname);
         return ResponseEntity.ok("사용자 차단이 해제되었습니다.");
     }

--- a/src/main/java/com/goorm/team9/icontact/domain/block/dto/BlockRequestDto.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/block/dto/BlockRequestDto.java
@@ -1,0 +1,16 @@
+package com.goorm.team9.icontact.domain.block.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class BlockRequestDto {
+
+    @Schema(example = "Noah1", description = "차단을 요청하는 사용자 닉네임")
+    private String blockerNickname;
+
+    @Schema(example = "Noah2", description = "차단될 사용자 닉네임")
+    private String blockedNickname;
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/block/dto/UnblockRequesetDto.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/block/dto/UnblockRequesetDto.java
@@ -1,0 +1,16 @@
+package com.goorm.team9.icontact.domain.block.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UnblockRequesetDto {
+
+    @Schema(example = "Noah1", description = "차단 해제를 요청하는 사용자 닉네임")
+    private String blockerNickname;
+
+    @Schema(example = "Noah2", description = "차단 해제될 사용자 닉네임")
+    private String blockedNickname;
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/controller/ChatRoomController.java
@@ -108,19 +108,20 @@ public class ChatRoomController {
 
     @Operation(summary = "사용자의 채팅방 조회 API", description = "특정 사용자가 참여한 채팅방 목록을 조회합니다.")
     @GetMapping("/{nickname}")
-    public ResponseEntity<List<ChatRoomResponse>> getChatRoomsByUser(
-            @RequestParam @Schema(example = "testUser") String nickname) {
+    public ResponseEntity<Object> getChatRoomsByUser(@PathVariable String nickname) {
         try {
             ClientEntity client = clientRepository.findByNickName(nickname)
                     .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
             List<ChatRoomResponse> chatRooms = chatRoomService.getChatRoomsByUser(client);
+
             if (chatRooms.isEmpty()) {
-                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+                return ResponseEntity.ok(Map.of("message", "사용자가 속해있는 채팅방이 없습니다."));
             }
-            return ResponseEntity.ok().body(chatRooms);
+            return ResponseEntity.ok(chatRooms);
         } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "서버 내부 오류가 발생했습니다."));
         }
     }
 

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/controller/ChatRoomController.java
@@ -6,6 +6,7 @@ import com.goorm.team9.icontact.domain.chat.service.ChatRoomService;
 import com.goorm.team9.icontact.domain.client.entity.ClientEntity;
 import com.goorm.team9.icontact.domain.client.repository.ClientRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -50,13 +51,20 @@ public class ChatRoomController {
     }
 
     @Operation(summary = "채팅 승인 API", description = "채팅 신청을 승인하여 채팅방을 개설합니다.")
-    @PostMapping("/request/{requestId}/accept")
-    public ResponseEntity<Map<String, Object>> acceptChatRequest(@PathVariable Long requestId) {
+    @PostMapping("/request/accept")
+    public ResponseEntity<Map<String, Object>> acceptChatRequest(
+            @RequestBody
+            @Schema(example = "{\"requestId\": 123}")
+            Map<String, Long> request) {
+
         Map<String, Object> response = new HashMap<>();
         try {
+            Long requestId = request.get("requestId");
             Long roomId = chatRoomService.acceptChatRequest(requestId);
+
             response.put("roomId", roomId);
             response.put("message", "채팅 요청이 승인되었습니다.");
+
             return ResponseEntity.ok(response);
         } catch (IllegalArgumentException e) {
             response.put("error", e.getMessage());
@@ -65,15 +73,28 @@ public class ChatRoomController {
     }
 
     @Operation(summary = "채팅 거절 API", description = "채팅 신청을 거절합니다.")
-    @PostMapping("/request/{requestId}/reject")
-    public ResponseEntity<Map<String, Object>> rejectChatRequest(@PathVariable Long requestId) {
+    @PostMapping("/request/reject")
+    public ResponseEntity<Map<String, Object>> rejectChatRequest(
+            @RequestBody
+            @Schema(example = "{\"requestId\": 123}")
+            Map<String, Long> request) {
+
+        Long requestId = request.get("requestId");
         chatRoomService.rejectChatRequest(requestId);
+
         return ResponseEntity.ok(Map.of("message", "채팅 요청이 거절되었습니다."));
     }
 
     @Operation(summary = "채팅방 퇴장 API", description = "사용자가 특정 채팅방을 나갑니다.")
-    @PostMapping("/{roomId}/exit/{clientId}")
-    public ResponseEntity<Map<String, String>> exitChatRoom(@PathVariable Long roomId, @PathVariable Long clientId) {
+    @PostMapping("/exit")
+    public ResponseEntity<Map<String, String>> exitChatRoom(
+            @RequestBody
+            @Schema(example = "{\"roomId\": 123, \"clientId\": 456}")
+            Map<String, Long> request) {
+
+        Long roomId = request.get("roomId");
+        Long clientId = request.get("clientId");
+
         ClientEntity client = clientRepository.findById(clientId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
@@ -87,7 +108,8 @@ public class ChatRoomController {
 
     @Operation(summary = "사용자의 채팅방 조회 API", description = "특정 사용자가 참여한 채팅방 목록을 조회합니다.")
     @GetMapping("/{nickname}")
-    public ResponseEntity<List<ChatRoomResponse>> getChatRoomsByUser(@PathVariable String nickname) {
+    public ResponseEntity<List<ChatRoomResponse>> getChatRoomsByUser(
+            @RequestParam @Schema(example = "testUser") String nickname) {
         try {
             ClientEntity client = clientRepository.findByNickName(nickname)
                     .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/dto/ChatRequestDto.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/dto/ChatRequestDto.java
@@ -1,0 +1,16 @@
+package com.goorm.team9.icontact.domain.chat.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChatRequestDto {
+
+    @Schema(example = "Noah1", description = "채팅을 요청하는 사용자 닉네임")
+    private String senderNickname;
+
+    @Schema(example = "Noah2", description = "채팅 요청을 받는 사용자 닉네임")
+    private String receiverNickname;
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/dto/ChatResponseDto.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/dto/ChatResponseDto.java
@@ -1,0 +1,16 @@
+package com.goorm.team9.icontact.domain.chat.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ChatResponseDto {
+
+    @Schema(example = "100", description = "채팅 요청 ID")
+    private final Long requestId;
+
+    @Schema(example = "채팅이 요청되었습니다.", description = "응답 메시지")
+    private final String message;
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/entity/ChatRequest.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/entity/ChatRequest.java
@@ -28,6 +28,10 @@ public class ChatRequest {
     @Enumerated(EnumType.STRING)
     private RequestStatus status;
 
+    public static ChatRequest create(ClientEntity senderNickname, ClientEntity receiverNickname) {
+        return new ChatRequest(senderNickname, receiverNickname);
+    }
+
     public ChatRequest(ClientEntity senderNickname, ClientEntity receiverNickname) {
         this.senderNickname = senderNickname;
         this.receiverNickname = receiverNickname;

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/repository/ChatJoinRepository.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/repository/ChatJoinRepository.java
@@ -19,6 +19,6 @@ public interface ChatJoinRepository extends JpaRepository<ChatJoin, Long> {
             "WHERE cj.chatRoom = :chatRoom AND cj.exited = false")
     long countByChatRoomAndExitedFalse(@Param("chatRoom") ChatRoom chatRoom);
 
-    @Query("SELECT cj FROM ChatJoin cj WHERE cj.chatRoom = :chatRoom AND cj.exited = false")
+    @Query("SELECT cj FROM ChatJoin cj WHERE cj.chatRoom = :chatRoom")
     List<ChatJoin> findByChatRoom(@Param("chatRoom") ChatRoom chatRoom);
 }

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/repository/ChatRequestRepository.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/repository/ChatRequestRepository.java
@@ -3,9 +3,16 @@ package com.goorm.team9.icontact.domain.chat.repository;
 import com.goorm.team9.icontact.domain.chat.entity.ChatRequest;
 import com.goorm.team9.icontact.domain.chat.entity.RequestStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface ChatRequestRepository extends JpaRepository<ChatRequest, Long> {
     Optional<ChatRequest> findByIdAndStatus(Long requestId, RequestStatus status);
+
+    @Query("SELECT cr FROM ChatRequest cr WHERE " +
+            "cr.senderNickname.nickName = :sender AND cr.receiverNickname.nickName = :receiver " +
+            "AND cr.status = 'PENDING'")
+    Optional<ChatRequest> findPendingRequest(@Param("sender") String sender, @Param("receiver") String receiver);
 }

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/repository/ChatRoomRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
@@ -13,4 +14,9 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             "FROM ChatRoom c" +
             " WHERE c.senderNickname.nickName = :nickname OR c.receiverNickname.nickName = :nickname")
     List<ChatRoom> findBySenderNicknameOrReceiverNickname(@Param("nickname") String nickname);
+
+    @Query("SELECT c FROM ChatRoom c WHERE " +
+            "(c.senderNickname.nickName = :sender AND c.receiverNickname.nickName = :receiver) " +
+            "OR (c.senderNickname.nickName = :receiver AND c.receiverNickname.nickName = :sender)")
+    Optional<ChatRoom> findExistingChatRoom(@Param("sender") String sender, @Param("receiver") String receiver);
 }

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/service/ChatRoomService.java
@@ -51,6 +51,11 @@ public class ChatRoomService {
 
     @Transactional
     public Long createChatRoom(ClientEntity sender, ClientEntity receiver) {
+        Optional<ChatRoom> existingChatRoom = chatRoomRepository.findExistingChatRoom(sender.getNickName(), receiver.getNickName());
+
+        if (existingChatRoom.isPresent()) {
+            throw new IllegalArgumentException("이미 채팅방이 존재합니다.");
+        }
 
         ChatRoom chatRoom = ChatRoom.createChatRoom(sender, receiver);
         chatRoomRepository.save(chatRoom);
@@ -72,6 +77,12 @@ public class ChatRoomService {
 
     @Transactional
     public Long requestChat(ClientEntity senderNickname, ClientEntity receiverNickname) {
+        Optional<ChatRoom> existingChatRoom = chatRoomRepository.findExistingChatRoom(senderNickname.getNickName(), receiverNickname.getNickName());
+
+        if (existingChatRoom.isPresent()) {
+            throw new IllegalArgumentException("이미 채팅방이 존재합니다.");
+        }
+
         ChatRequest chatRequest = new ChatRequest(senderNickname, receiverNickname);
         chatRequestRepository.save(chatRequest);
         return chatRequest.getId();

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/service/ChatRoomService.java
@@ -91,9 +91,8 @@ public class ChatRoomService {
             throw new IllegalArgumentException("이미 채팅 요청을 보냈습니다.");
         }
 
-        ChatRequest chatRequest = new ChatRequest(senderNickname, receiverNickname);
-        chatRequestRepository.save(chatRequest);
-        return chatRequest.getId();
+        ChatRequest chatRequest = ChatRequest.create(senderNickname, receiverNickname);
+        return chatRequestRepository.save(chatRequest).getId();
     }
 
     @Transactional

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/service/ChatRoomService.java
@@ -11,10 +11,12 @@ import com.goorm.team9.icontact.domain.chat.repository.ChatRoomRepository;
 import com.goorm.team9.icontact.domain.client.entity.ClientEntity;
 import com.goorm.team9.icontact.domain.client.repository.ClientRepository;
 import com.goorm.team9.icontact.domain.client.service.ClientService;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -145,15 +147,16 @@ public class ChatRoomService {
     }
 
     public List<ChatRoomResponse> getChatRoomsByUser(ClientEntity client) {
-        List<ChatRoom> chatRooms = chatRoomRepository.findBySenderNicknameOrReceiverNickname(client.getNickName());
-
-        return chatRooms.stream()
+        List<ChatRoomResponse> chatRooms = chatRoomRepository.findBySenderNicknameOrReceiverNickname(client.getNickName())
+                .stream()
                 .filter(chatRoom -> {
                     Optional<ChatJoin> chatJoin = chatJoinRepository.findByChatRoomAndClientId(chatRoom, client.getId());
                     return chatJoin.isEmpty() || !chatJoin.get().isExited();
                 })
                 .map(ChatRoomResponse::fromEntity)
                 .collect(Collectors.toList());
+
+        return chatRooms;
     }
 
     public List<ChatRoomResponse> getAllChatRooms() {

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/service/ChatRoomService.java
@@ -83,6 +83,12 @@ public class ChatRoomService {
             throw new IllegalArgumentException("이미 채팅방이 존재합니다.");
         }
 
+        Optional<ChatRequest> existingRequest = chatRequestRepository.findPendingRequest(senderNickname.getNickName(), receiverNickname.getNickName());
+
+        if (existingRequest.isPresent()) {
+            throw new IllegalArgumentException("이미 채팅 요청을 보냈습니다.");
+        }
+
         ChatRequest chatRequest = new ChatRequest(senderNickname, receiverNickname);
         chatRequestRepository.save(chatRequest);
         return chatRequest.getId();

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/service/ChatRoomService.java
@@ -139,6 +139,7 @@ public class ChatRoomService {
         long remainingUsers = chatJoinRepository.countByChatRoomAndExitedFalse(chatRoom);
 
         if (remainingUsers == 0) {
+            chatJoinRepository.deleteAll(chatJoinRepository.findByChatRoom(chatRoom));
             chatRoomRepository.delete(chatRoom);
         }
     }


### PR DESCRIPTION
## 📋 Summary

> - closes #57 
> - 채팅 api 수정
> - 채팅 관련 테스트 중 발견한 에러 해결 및 수정

## ✅ Tasks

- 채팅 api json으로 통일
- 이미 채팅방이 존재하는 경우 요청 및 생성을 차단하는 기능 추가
- 이미 채팅 요청했을 경우 재요청을 차단하는 기능 추가
- 마지막 사용자가 채팅방 퇴장 시 에러 발생 문제 해결
- 채팅방 조회 시 없는 경우 에러 대신 메시지 반환하도록 수정

## ✏️ To Reviewer

스웨거에서 채팅 관련 테스트해보면서 에러 및 수정하면 좋을 부분 발견해서 진행했습니다.

## 📷 Screenshot

