### PR TITLE
[#77] 채팅방 요청 필터링 구현

### DIFF
--- a/src/main/java/com/goorm/team9/icontact/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/controller/ChatMessageController.java
@@ -4,11 +4,17 @@ import com.goorm.team9.icontact.domain.chat.dto.ChatMessageDto;
 import com.goorm.team9.icontact.domain.chat.entity.ChatMessageType;
 import com.goorm.team9.icontact.domain.chat.service.ChatMessageService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -46,5 +52,14 @@ public class ChatMessageController {
         String errorMessage = e.getMessage();
         messagingTemplate.convertAndSend("/queue/" + chatMessageDto.getRoomId(), errorMessage);
         }
+    }
+
+    @GetMapping("/{roomId}/messages")
+    public ResponseEntity<List<ChatMessageDto>> getMessagesByRoomId(
+            @PathVariable Long roomId,
+            @RequestParam Long clientId) {
+
+        List<ChatMessageDto> messages = chatMessageService.getMessagesByRoomId(roomId, clientId);
+        return ResponseEntity.ok(messages);
     }
 }

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/controller/ChatRequestController.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/controller/ChatRequestController.java
@@ -1,0 +1,69 @@
+package com.goorm.team9.icontact.domain.chat.controller;
+
+import com.goorm.team9.icontact.domain.chat.dto.ChatRequestDto;
+import com.goorm.team9.icontact.domain.chat.dto.ChatResponseDto;
+import com.goorm.team9.icontact.domain.chat.entity.ChatRequest;
+import com.goorm.team9.icontact.domain.chat.service.ChatRoomService;
+import com.goorm.team9.icontact.domain.client.entity.ClientEntity;
+import com.goorm.team9.icontact.domain.client.repository.ClientRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Tag(name = "Chat Request API", description = "채팅 요청 API")
+@RestController
+@RequestMapping("/api/chat/request")
+public class ChatRequestController {
+
+    private final ChatRoomService chatRoomService;
+    private final ClientRepository clientRepository;
+
+    public ChatRequestController(ChatRoomService chatRoomService, ClientRepository clientRepository) {
+        this.chatRoomService = chatRoomService;
+        this.clientRepository = clientRepository;
+    }
+
+    @Operation(summary = "채팅 요청 API", description = "상대방에게 채팅을 요청을 보냅니다.")
+    @PostMapping
+    public ResponseEntity<ChatResponseDto> requestChat(@RequestBody ChatRequestDto requestDto) {
+        ClientEntity sender = clientRepository.findByNickName(requestDto.getSenderNickname())
+                .orElseThrow(() -> new IllegalArgumentException("발신자를 찾을 수 없습니다."));
+        ClientEntity receiver = clientRepository.findByNickName(requestDto.getReceiverNickname())
+                .orElseThrow(() -> new IllegalArgumentException("수신자를 찾을 수 없습니다."));
+
+        Long requestId = chatRoomService.requestChat(sender, receiver);
+        return ResponseEntity.ok(new ChatResponseDto(requestId, "채팅이 요청되었습니다."));
+    }
+
+    @Operation(summary = "채팅 요청 상태 확인", description = "요청 상태를 확인합니다.")
+    @GetMapping("/{id}")
+    public ResponseEntity<ChatResponseDto> getChatRequest(@PathVariable Long id) {
+        Optional<ChatRequest> chatRequest = chatRoomService.getChatRequestById(id);
+        if (chatRequest.isPresent()) {
+            return ResponseEntity.ok(new ChatResponseDto(chatRequest.get().getId(), chatRequest.get().getStatus().toString()));
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @Operation(summary = "채팅 승인 API", description = "채팅 신청을 승인하여 채팅방을 개설합니다.")
+    @PatchMapping("/accept")
+    public ResponseEntity<ChatResponseDto> acceptChatRequest(@PathVariable Long id) {
+        Long roomId = chatRoomService.acceptChatRequest(id);
+        return ResponseEntity.ok(new ChatResponseDto(roomId, "채팅 요청이 수락되었습니다."));
+    }
+
+    @Operation(summary = "채팅 거절 API", description = "채팅 신청을 거절합니다.")
+    @PatchMapping("/reject")
+    public ResponseEntity<ChatResponseDto> rejectChatRequest(@PathVariable Long id) {
+        chatRoomService.rejectChatRequest(id);
+        return ResponseEntity.ok(new ChatResponseDto(id, "채팅 요청이 거절되었습니다."));
+    }
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/controller/ChatRequestController.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/controller/ChatRequestController.java
@@ -7,14 +7,10 @@ import com.goorm.team9.icontact.domain.chat.service.ChatRoomService;
 import com.goorm.team9.icontact.domain.client.entity.ClientEntity;
 import com.goorm.team9.icontact.domain.client.repository.ClientRepository;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 
 @Tag(name = "Chat Request API", description = "채팅 요청 API")
@@ -38,8 +34,7 @@ public class ChatRequestController {
         ClientEntity receiver = clientRepository.findByNickName(requestDto.getReceiverNickname())
                 .orElseThrow(() -> new IllegalArgumentException("수신자를 찾을 수 없습니다."));
 
-        Long requestId = chatRoomService.requestChat(sender, receiver);
-        return ResponseEntity.ok(new ChatResponseDto(requestId, "채팅이 요청되었습니다."));
+        return chatRoomService.requestChat(sender, receiver);
     }
 
     @Operation(summary = "채팅 요청 상태 확인", description = "요청 상태를 확인합니다.")

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/controller/ChatRequestController.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/controller/ChatRequestController.java
@@ -1,8 +1,11 @@
 package com.goorm.team9.icontact.domain.chat.controller;
 
+import com.goorm.team9.icontact.domain.chat.dto.ChatRequestCountDto;
 import com.goorm.team9.icontact.domain.chat.dto.ChatRequestDto;
 import com.goorm.team9.icontact.domain.chat.dto.ChatResponseDto;
 import com.goorm.team9.icontact.domain.chat.entity.ChatRequest;
+import com.goorm.team9.icontact.domain.chat.entity.RequestStatus;
+import com.goorm.team9.icontact.domain.chat.service.ChatRequestService;
 import com.goorm.team9.icontact.domain.chat.service.ChatRoomService;
 import com.goorm.team9.icontact.domain.client.entity.ClientEntity;
 import com.goorm.team9.icontact.domain.client.repository.ClientRepository;
@@ -11,6 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Optional;
 
 @Tag(name = "Chat Request API", description = "채팅 요청 API")
@@ -20,10 +24,12 @@ public class ChatRequestController {
 
     private final ChatRoomService chatRoomService;
     private final ClientRepository clientRepository;
+    private final ChatRequestService chatRequestService;
 
-    public ChatRequestController(ChatRoomService chatRoomService, ClientRepository clientRepository) {
+    public ChatRequestController(ChatRoomService chatRoomService, ClientRepository clientRepository, ChatRequestService chatRequestService) {
         this.chatRoomService = chatRoomService;
         this.clientRepository = clientRepository;
+        this.chatRequestService = chatRequestService;
     }
 
     @Operation(summary = "채팅 요청 API", description = "상대방에게 채팅을 요청을 보냅니다.")
@@ -34,13 +40,13 @@ public class ChatRequestController {
         ClientEntity receiver = clientRepository.findByNickName(requestDto.getReceiverNickname())
                 .orElseThrow(() -> new IllegalArgumentException("수신자를 찾을 수 없습니다."));
 
-        return chatRoomService.requestChat(sender, receiver);
+        return chatRequestService.requestChat(sender, receiver);
     }
 
     @Operation(summary = "채팅 요청 상태 확인", description = "요청 상태를 확인합니다.")
     @GetMapping("/{id}")
     public ResponseEntity<ChatResponseDto> getChatRequest(@PathVariable Long id) {
-        Optional<ChatRequest> chatRequest = chatRoomService.getChatRequestById(id);
+        Optional<ChatRequest> chatRequest = chatRequestService.getChatRequestById(id);
         if (chatRequest.isPresent()) {
             return ResponseEntity.ok(new ChatResponseDto(chatRequest.get().getId(), chatRequest.get().getStatus().toString()));
         } else {
@@ -51,14 +57,39 @@ public class ChatRequestController {
     @Operation(summary = "채팅 승인 API", description = "채팅 신청을 승인하여 채팅방을 개설합니다.")
     @PatchMapping("/accept")
     public ResponseEntity<ChatResponseDto> acceptChatRequest(@PathVariable Long id) {
-        Long roomId = chatRoomService.acceptChatRequest(id);
+        Long roomId = chatRequestService.acceptChatRequest(id);
         return ResponseEntity.ok(new ChatResponseDto(roomId, "채팅 요청이 수락되었습니다."));
     }
 
     @Operation(summary = "채팅 거절 API", description = "채팅 신청을 거절합니다.")
     @PatchMapping("/reject")
     public ResponseEntity<ChatResponseDto> rejectChatRequest(@PathVariable Long id) {
-        chatRoomService.rejectChatRequest(id);
+        chatRequestService.rejectChatRequest(id);
         return ResponseEntity.ok(new ChatResponseDto(id, "채팅 요청이 거절되었습니다."));
+    }
+
+    @Operation(summary = "받은 채팅 요청 조회 API", description = "사용자가 받은 채팅 요청을 조회합니다.")
+    @GetMapping("/received")
+    public ResponseEntity<List<ChatRequestDto>> getReceivedRequests(
+            @RequestParam String receiverNickname,
+            @RequestParam RequestStatus status) {
+        List<ChatRequestDto> receivedRequests = chatRequestService.getReceivedRequests(receiverNickname, status);
+        return ResponseEntity.ok(receivedRequests);
+    }
+
+    @Operation(summary = "보낸 채팅 요청 조회 API", description = "사용자가 보낸 채팅 요청을 조회합니다.")
+    @GetMapping("/sent")
+    public ResponseEntity<List<ChatRequestDto>> getSentRequests(
+            @RequestParam String senderNickname,
+            @RequestParam RequestStatus status) {
+        List<ChatRequestDto> sentRequests = chatRequestService.getSentRequest(senderNickname, status);
+        return ResponseEntity.ok(sentRequests);
+    }
+
+    @Operation(summary = "요청 개수 조회 API", description = "사용자가 받은 요청과 보낸 요청의 개수를 반환합니다.")
+    @GetMapping("/count")
+    public ResponseEntity<ChatRequestCountDto> getRequestCounts(@RequestParam String nickname) {
+        ChatRequestCountDto countDto = chatRequestService.getRequestCounts(nickname);
+        return ResponseEntity.ok(countDto);
     }
 }

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/controller/ChatRoomController.java
@@ -1,7 +1,5 @@
 package com.goorm.team9.icontact.domain.chat.controller;
 
-import com.goorm.team9.icontact.domain.chat.dto.ChatRequestDto;
-import com.goorm.team9.icontact.domain.chat.dto.ChatResponseDto;
 import com.goorm.team9.icontact.domain.chat.dto.ChatRoomRequest;
 import com.goorm.team9.icontact.domain.chat.dto.ChatRoomResponse;
 import com.goorm.team9.icontact.domain.chat.service.ChatRoomService;
@@ -29,55 +27,6 @@ public class ChatRoomController {
     public ChatRoomController(ChatRoomService chatRoomService, ClientRepository clientRepository) {
         this.chatRoomService = chatRoomService;
         this.clientRepository = clientRepository;
-    }
-
-    @Operation(summary = "채팅 신청 API", description = "상대방에게 채팅을 신청합니다.")
-    @PostMapping("/request")
-    public ResponseEntity<ChatResponseDto> requestChat(@RequestBody ChatRequestDto requestDto) {
-        ClientEntity sender = clientRepository.findByNickName(requestDto.getSenderNickname())
-                .orElseThrow(() -> new IllegalArgumentException("발신자를 찾을 수 없습니다."));
-        ClientEntity receiver = clientRepository.findByNickName(requestDto.getReceiverNickname())
-                .orElseThrow(() -> new IllegalArgumentException("수신자를 찾을 수 없습니다."));
-
-        Long requestId = chatRoomService.requestChat(sender, receiver);
-        ChatResponseDto responseDto = new ChatResponseDto(requestId, "채팅이 요청되었습니다.");
-
-        return ResponseEntity.ok(responseDto);
-    }
-
-    @Operation(summary = "채팅 승인 API", description = "채팅 신청을 승인하여 채팅방을 개설합니다.")
-    @PostMapping("/request/accept")
-    public ResponseEntity<Map<String, Object>> acceptChatRequest(
-            @RequestBody
-            @Schema(example = "{\"requestId\": 123}")
-            Map<String, Long> request) {
-
-        Map<String, Object> response = new HashMap<>();
-        try {
-            Long requestId = request.get("requestId");
-            Long roomId = chatRoomService.acceptChatRequest(requestId);
-
-            response.put("roomId", roomId);
-            response.put("message", "채팅 요청이 승인되었습니다.");
-
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            response.put("error", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
-        }
-    }
-
-    @Operation(summary = "채팅 거절 API", description = "채팅 신청을 거절합니다.")
-    @PostMapping("/request/reject")
-    public ResponseEntity<Map<String, Object>> rejectChatRequest(
-            @RequestBody
-            @Schema(example = "{\"requestId\": 123}")
-            Map<String, Long> request) {
-
-        Long requestId = request.get("requestId");
-        chatRoomService.rejectChatRequest(requestId);
-
-        return ResponseEntity.ok(Map.of("message", "채팅 요청이 거절되었습니다."));
     }
 
     @Operation(summary = "채팅방 퇴장 API", description = "사용자가 특정 채팅방을 나갑니다.")

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/dto/ChatMessageDto.java
@@ -1,43 +1,64 @@
 package com.goorm.team9.icontact.domain.chat.dto;
 
+import com.goorm.team9.icontact.domain.chat.entity.ChatMessage;
 import com.goorm.team9.icontact.domain.chat.entity.ChatMessageType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class ChatMessageDto {
 
+    private Long messageId;
     private Long roomId;
     private String senderNickname;
     private String content;
-
     private ChatMessageType type;
+    private LocalDateTime timeStamp;
+
+    public static ChatMessageDto fromEntity(ChatMessage chatMessage) {
+        return ChatMessageDto.builder()
+                .messageId(chatMessage.getId())
+                .roomId(chatMessage.getChatRoom().getRoomId())
+                .senderNickname(chatMessage.getSenderNickname().getNickName())
+                .content(chatMessage.getContent())
+                .type(chatMessage.getType())
+                .timeStamp(chatMessage.getCreated_at())
+                .build();
+    }
 
     public static ChatMessageDto createChatMessage(Long roomId, String senderNickname, String content) {
-        ChatMessageDto message = new ChatMessageDto();
-        message.roomId = roomId;
-        message.senderNickname = senderNickname;
-        message.content = content;
-        message.type = ChatMessageType.CHAT;
-        return message;
+        return ChatMessageDto.builder()
+                .roomId(roomId)
+                .senderNickname(senderNickname)
+                .content(content)
+                .type(ChatMessageType.CHAT)
+                .timeStamp(LocalDateTime.now())
+                .build();
     }
 
     public static ChatMessageDto createJoinMessage(Long roomId, String senderNickname) {
-        ChatMessageDto message = new ChatMessageDto();
-        message.roomId = roomId;
-        message.senderNickname = senderNickname;
-        message.content = senderNickname + "님과의 대화가 시작되었어요.";
-        message.type = ChatMessageType.JOIN;
-        return message;
+        return ChatMessageDto.builder()
+                .roomId(roomId)
+                .senderNickname(senderNickname)
+                .content(senderNickname + "님과의 대화가 시작되었어요.")
+                .type(ChatMessageType.JOIN)
+                .timeStamp(LocalDateTime.now())
+                .build();
     }
-
     public static ChatMessageDto createLeaveMessage(Long roomId, String senderNickname) {
-        ChatMessageDto message = new ChatMessageDto();
-        message.roomId = roomId;
-        message.senderNickname = senderNickname;
-        message.content = senderNickname + "님이 퇴장했습니다.";
-        message.type = ChatMessageType.LEAVE;
-        return message;
+        return ChatMessageDto.builder()
+                .roomId(roomId)
+                .senderNickname(senderNickname)
+                .content(senderNickname + "님이 퇴장했습니다.")
+                .type(ChatMessageType.LEAVE)
+                .timeStamp(LocalDateTime.now())
+                .build();
     }
 }

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/dto/ChatRequestCountDto.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/dto/ChatRequestCountDto.java
@@ -1,0 +1,13 @@
+package com.goorm.team9.icontact.domain.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatRequestCountDto {
+    private long receivedCount;
+    private long sentCount;
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/dto/ChatRequestDto.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/dto/ChatRequestDto.java
@@ -1,16 +1,34 @@
 package com.goorm.team9.icontact.domain.chat.dto;
 
+import com.goorm.team9.icontact.domain.chat.entity.ChatRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class ChatRequestDto {
+
+    private Long id;
 
     @Schema(example = "Noah1", description = "채팅을 요청하는 사용자 닉네임")
     private String senderNickname;
 
     @Schema(example = "Noah2", description = "채팅 요청을 받는 사용자 닉네임")
     private String receiverNickname;
+
+    private String status;
+
+    public static ChatRequestDto fromEntity(ChatRequest chatRequest) {
+        return ChatRequestDto.builder()
+                .id(chatRequest.getId())
+                .senderNickname(chatRequest.getSenderNickname().getNickName())
+                .receiverNickname(chatRequest.getReceiverNickname().getNickName())
+                .status(chatRequest.getStatus().toString())
+                .build();
+    }
 }

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/repository/ChatJoinRepository.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/repository/ChatJoinRepository.java
@@ -19,4 +19,9 @@ public interface ChatJoinRepository extends JpaRepository<ChatJoin, Long> {
 
     @Query("SELECT cj FROM ChatJoin cj WHERE cj.chatRoom = :chatRoom")
     List<ChatJoin> findByChatRoom(@Param("chatRoom") ChatRoom chatRoom);
+
+    @Query("SELECT COUNT(cj) > 0 " +
+            "FROM ChatJoin cj " +
+            "WHERE cj.chatRoom = :chatRoom AND cj.client.id = :clientId")
+    boolean existsByChatRoomAndClientId(@Param("chatRoom") ChatRoom chatRoom, @Param("clientId") Long clientId);
 }

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/repository/ChatMessageRepository.java
@@ -15,4 +15,7 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
             "WHERE m.chatRoom.roomId = :chatRoomId " +
             "AND m.created_at > (SELECT cj.lastReadAt FROM ChatJoin cj WHERE cj.chatRoom.roomId = :chatRoomId AND cj.client.id = :clientId)")
     long countUnreadMessages(@Param("chatRoomId") Long chatRoomId, @Param("clientId") Long clientId);
+
+    @Query("SELECT m FROM ChatMessage m WHERE m.chatRoom.roomId = :roomId ORDER BY m.created_at ASC")
+    List<ChatMessage> findByChatRoomId(@Param("roomId") Long roomId);
 }

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/repository/ChatRequestRepository.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/repository/ChatRequestRepository.java
@@ -2,10 +2,12 @@ package com.goorm.team9.icontact.domain.chat.repository;
 
 import com.goorm.team9.icontact.domain.chat.entity.ChatRequest;
 import com.goorm.team9.icontact.domain.chat.entity.RequestStatus;
+import com.goorm.team9.icontact.domain.client.entity.ClientEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ChatRequestRepository extends JpaRepository<ChatRequest, Long> {
@@ -15,4 +17,20 @@ public interface ChatRequestRepository extends JpaRepository<ChatRequest, Long> 
             "cr.senderNickname.nickName = :sender AND cr.receiverNickname.nickName = :receiver " +
             "AND cr.status = 'PENDING'")
     Optional<ChatRequest> findPendingRequest(@Param("sender") String sender, @Param("receiver") String receiver);
+
+    List<ChatRequest> findByReceiverNicknameAndStatus(ClientEntity receiver, RequestStatus status);
+
+    List<ChatRequest> findBySenderNicknameAndStatus(ClientEntity sender, RequestStatus status);
+
+    @Query("SELECT COUNT(cr) " +
+            "FROM ChatRequest cr " +
+            "WHERE cr.receiverNickname = :receiver AND cr.status = :status")
+    long countReceivedRequests(@Param("receiver") ClientEntity receiver, @Param("status") RequestStatus status);
+
+    @Query("SELECT COUNT(cr) " +
+            "FROM ChatRequest cr " +
+            "WHERE cr.senderNickname = :sender AND cr.status = :status")
+    long countSentRequests(@Param("sender") ClientEntity sender, @Param("status") RequestStatus status);
+
+    List<ChatRequest> status(RequestStatus status);
 }

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/service/ChatMessageService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -82,5 +83,24 @@ public class ChatMessageService {
         }
 
         return chatMessageRepository.findByChatRoom(chatRoom);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatMessageDto> getMessagesByRoomId(Long roomId, Long clientId) {
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 채팅방을 찾을 수 없습니다."));
+
+        ClientEntity client = clientRepository.findById(clientId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        boolean isMember = chatJoinRepository.existsByChatRoomAndClientId(chatRoom, clientId);
+        if (!isMember) {
+            throw new IllegalArgumentException("해당 채팅방에 속해있지 않습니다.");
+        }
+
+        return chatMessageRepository.findByChatRoomId(roomId)
+                .stream()
+                .map(ChatMessageDto::fromEntity)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/service/ChatRequestService.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/service/ChatRequestService.java
@@ -1,0 +1,120 @@
+package com.goorm.team9.icontact.domain.chat.service;
+
+import com.goorm.team9.icontact.domain.chat.dto.ChatRequestCountDto;
+import com.goorm.team9.icontact.domain.chat.dto.ChatRequestDto;
+import com.goorm.team9.icontact.domain.chat.dto.ChatResponseDto;
+import com.goorm.team9.icontact.domain.chat.entity.ChatRequest;
+import com.goorm.team9.icontact.domain.chat.entity.ChatRoom;
+import com.goorm.team9.icontact.domain.chat.entity.RequestStatus;
+import com.goorm.team9.icontact.domain.chat.repository.ChatRequestRepository;
+import com.goorm.team9.icontact.domain.chat.repository.ChatRoomRepository;
+import com.goorm.team9.icontact.domain.client.entity.ClientEntity;
+import com.goorm.team9.icontact.domain.client.repository.ClientRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.goorm.team9.icontact.domain.chat.entity.ChatRoom.createChatRoom;
+
+@Service
+public class ChatRequestService {
+
+    private final ChatRequestRepository chatRequestRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ClientRepository clientRepository;
+
+    public ChatRequestService(ChatRequestRepository chatRequestRepository, ChatRoomRepository chatRoomRepository, ClientRepository clientRepository) {
+        this.chatRequestRepository = chatRequestRepository;
+        this.chatRoomRepository = chatRoomRepository;
+        this.clientRepository = clientRepository;
+    }
+
+
+    @Transactional
+    public ResponseEntity<ChatResponseDto> requestChat(ClientEntity senderNickname, ClientEntity receiverNickname) {
+        Optional<ChatRoom> existingChatRoom = chatRoomRepository.findExistingChatRoom(senderNickname.getNickName(), receiverNickname.getNickName());
+
+        if (existingChatRoom.isPresent()) {
+            return ResponseEntity.ok(new ChatResponseDto(null, "이미 채팅방이 존재합니다."));
+        }
+
+        Optional<ChatRequest> existingRequest = chatRequestRepository.findPendingRequest(senderNickname.getNickName(), receiverNickname.getNickName());
+
+        if (existingRequest.isPresent()) {
+            return ResponseEntity.ok(new ChatResponseDto(existingRequest.get().getId(), "이미 채팅 요청을 보냈습니다."));
+        }
+
+        ChatRequest chatRequest = ChatRequest.create(senderNickname, receiverNickname);
+        Long requestId = chatRequestRepository.save(chatRequest).getId();
+
+        return ResponseEntity.ok(new ChatResponseDto(requestId, "채팅 요청이 정상적으로 전송되었습니다."));
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<ChatRequest> getChatRequestById(Long requestId) {
+        return chatRequestRepository.findById(requestId);
+    }
+
+    @Transactional
+    public Long acceptChatRequest(Long requestId) {
+        ChatRequest chatRequest = chatRequestRepository.findByIdAndStatus(requestId, RequestStatus.PENDING)
+                .orElseThrow(() -> new IllegalArgumentException("해당 요청이 없거나 이미 처리되었습니다."));
+
+        ClientEntity sender = chatRequest.getSenderNickname();
+        ClientEntity receiver = chatRequest.getReceiverNickname();
+
+        chatRequest.accept();
+        chatRequestRepository.save(chatRequest);
+
+        ChatRoom chatRoom = createChatRoom(sender, receiver);
+        chatRoomRepository.save(chatRoom);
+
+        return chatRoom.getRoomId();
+    }
+
+    public void rejectChatRequest(Long requestId) {
+        ChatRequest chatRequest = chatRequestRepository.findByIdAndStatus(requestId, RequestStatus.PENDING)
+                .orElseThrow(() -> new IllegalArgumentException("해당 요청이 없거나 이미 처리되었습니다."));
+
+        chatRequest.reject();
+        chatRequestRepository.save(chatRequest);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatRequestDto> getReceivedRequests(String receiverNickname, RequestStatus status) {
+        ClientEntity receiver = clientRepository.findByNickName(receiverNickname)
+                .orElseThrow(() -> new IllegalArgumentException("수신자를 찾을 수 없습니다."));
+
+        return chatRequestRepository.findByReceiverNicknameAndStatus(receiver, status)
+                .stream()
+                .map(ChatRequestDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatRequestDto> getSentRequest(String senderNickname, RequestStatus status) {
+        ClientEntity sender = clientRepository.findByNickName(senderNickname)
+                .orElseThrow(() -> new IllegalArgumentException("발신자를 찾을 수 없습니다."));
+
+        return chatRequestRepository.findBySenderNicknameAndStatus(sender, status)
+                .stream()
+                .map(ChatRequestDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public ChatRequestCountDto getRequestCounts(String nickname) {
+        ClientEntity client = clientRepository.findByNickName(nickname)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        long receivedCount = chatRequestRepository.countReceivedRequests(client, RequestStatus.PENDING);
+        long sentCount = chatRequestRepository.countSentRequests(client, RequestStatus.PENDING);
+
+        return new ChatRequestCountDto(receivedCount, sentCount);
+    }
+
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/service/ChatRoomService.java
@@ -96,6 +96,11 @@ public class ChatRoomService {
         return chatRequestRepository.save(chatRequest).getId();
     }
 
+    @Transactional(readOnly = true)
+    public Optional<ChatRequest> getChatRequestById(Long requestId) {
+        return chatRequestRepository.findById(requestId);
+    }
+
     @Transactional
     public Long acceptChatRequest(Long requestId) {
         ChatRequest chatRequest = chatRequestRepository.findByIdAndStatus(requestId, RequestStatus.PENDING)

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/service/ChatRoomService.java
@@ -81,55 +81,6 @@ public class ChatRoomService {
     }
 
     @Transactional
-    public ResponseEntity<ChatResponseDto> requestChat(ClientEntity senderNickname, ClientEntity receiverNickname) {
-        Optional<ChatRoom> existingChatRoom = chatRoomRepository.findExistingChatRoom(senderNickname.getNickName(), receiverNickname.getNickName());
-
-        if (existingChatRoom.isPresent()) {
-            return ResponseEntity.ok(new ChatResponseDto(null, "이미 채팅방이 존재합니다."));
-        }
-
-        Optional<ChatRequest> existingRequest = chatRequestRepository.findPendingRequest(senderNickname.getNickName(), receiverNickname.getNickName());
-
-        if (existingRequest.isPresent()) {
-            return ResponseEntity.ok(new ChatResponseDto(existingRequest.get().getId(), "이미 채팅 요청을 보냈습니다."));
-        }
-
-        ChatRequest chatRequest = ChatRequest.create(senderNickname, receiverNickname);
-        Long requestId = chatRequestRepository.save(chatRequest).getId();
-
-        return ResponseEntity.ok(new ChatResponseDto(requestId, "채팅 요청이 정상적으로 전송되었습니다."));
-    }
-
-    @Transactional(readOnly = true)
-    public Optional<ChatRequest> getChatRequestById(Long requestId) {
-        return chatRequestRepository.findById(requestId);
-    }
-
-    @Transactional
-    public Long acceptChatRequest(Long requestId) {
-        ChatRequest chatRequest = chatRequestRepository.findByIdAndStatus(requestId, RequestStatus.PENDING)
-                .orElseThrow(() -> new IllegalArgumentException("해당 요청이 없거나 이미 처리되었습니다."));
-
-        ClientEntity sender = chatRequest.getSenderNickname();
-        ClientEntity receiver = chatRequest.getReceiverNickname();
-
-        chatRequest.accept();
-        chatRequestRepository.save(chatRequest);
-
-        Long roomId = createChatRoom(sender, receiver);
-
-        return roomId;
-    }
-
-    public void rejectChatRequest(Long requestId) {
-        ChatRequest chatRequest = chatRequestRepository.findByIdAndStatus(requestId, RequestStatus.PENDING)
-                .orElseThrow(() -> new IllegalArgumentException("해당 요청이 없거나 이미 처리되었습니다."));
-
-        chatRequest.reject();
-        chatRequestRepository.save(chatRequest);
-    }
-
-    @Transactional
     public void exitChatRoom(Long roomId, Long clientId) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));


### PR DESCRIPTION
## 📋 Summary

> - closes #77

**해당 PR에 대한 요약을 작성해주세요.**

- 채팅방 요청 필터링 구현
- 요청 개수 조회 구현
- 요청 상태 조회 로직 추가
## ✅ Tasks

- 채팅 요청 관련 로직 분리 : ChatRequestController, ChatRequestService -> 가독성 🆙
- 채팅 요청 상태 조회하는 로직 추가
- 채팅방별 채팅 메시지 조회 api 추가
- 채팅 요청 목록 필터링(받은 요청 / 보낸 요청) 구현
- 요청 개수 조회 api 추가

## ✏️ To Reviewer

요청 목록 필터링 구현했습니다. 하면서 요청 관련 코드는 분리하는 것이 좋겠다고 판단해서 로직 분리했습니다.
수정이 필요한 부분이 있다면 피드백 주세요!
프론트에서 추가 요청하신 채팅 요청 상태 조회 api와 각 채팅방별 채팅 메시지 조회 api도 함께 추가해두었습니다.

## 📷 Screenshot

❌
