### PR TITLE
[#66] 온라인 알림 전송

### DIFF
--- a/src/main/java/com/goorm/team9/icontact/domain/chat/dto/ChatMessageNotificationDto.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/dto/ChatMessageNotificationDto.java
@@ -1,0 +1,15 @@
+package com.goorm.team9.icontact.domain.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class ChatMessageNotificationDto {
+    private String senderNickname;
+    private String messagePreview;
+    private Long roomId;
+    private LocalDateTime sentAt;
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/dto/ChatRequestNotificationDto.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/dto/ChatRequestNotificationDto.java
@@ -1,0 +1,14 @@
+package com.goorm.team9.icontact.domain.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class ChatRequestNotificationDto {
+    private String senderNickname;
+    private Long requestId;
+    private LocalDateTime requestedAt;
+}


### PR DESCRIPTION
## 📋 Summary

> - closes #66 
> - 사용자가 온라인에 접속해있을 경우 알림을 전송한다.
> - 알림 관련 dto 추가, 서비스 코드 추가

## ✅ Tasks

- 사용자에게 채팅 요청이 왔을 때 채팅 요청 알림 전송 구현
- 채팅 메시지가 왔을 경우 알림 전송 구현

## ✏️ To Reviewer

기존에 구현해두었던 웹소켓과 stomp만을 이용해 온라인 알림 전송 구현했습니다. 수정하거나 추가해야할 부분 있으면 피드백 주세요.

## 📷 Screenshot

❌
