### PR TITLE
[#101] 요청시 이미지 반환해주는 API 구현

### DIFF
--- a/src/main/java/com/goorm/team9/icontact/domain/client/controller/ClientController.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/client/controller/ClientController.java
@@ -3,6 +3,7 @@ package com.goorm.team9.icontact.domain.client.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.goorm.team9.icontact.domain.client.dto.request.MyPageCreateRequest;
 import com.goorm.team9.icontact.domain.client.dto.request.MyPageUpdateRequest;
+import com.goorm.team9.icontact.domain.client.dto.response.ClientProfileImageDTO;
 import com.goorm.team9.icontact.domain.client.dto.response.ClientResponseDTO;
 import com.goorm.team9.icontact.domain.client.service.ClientService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -70,6 +71,19 @@ public class ClientController {
     @Operation(summary = "전체 사용자 조회 API", description = "삭제되지 않은 모든 사용자의 정보를 반환합니다.")
     public ResponseEntity<List<ClientResponseDTO>> getAllClients() {
         return ResponseEntity.ok(clientService.getAllClients());
+    }
+
+    @GetMapping("/profile-images")
+    @Operation(summary = "사용자 프로필 이미지 조회 API", description = "최대 10명의 사용자 ID를 입력받아 각자의 프로필 이미지를 반환합니다.")
+    public ResponseEntity<?> getProfileImages(
+            @RequestParam(required = false) List<Long> clientIds
+    ) {
+        if (clientIds == null || clientIds.size() > 10) {
+            return ResponseEntity.badRequest().body("clientId는 최대 10개까지 입력 가능합니다.");
+        }
+
+        List<ClientProfileImageDTO> images = clientService.getProfileImages(clientIds);
+        return ResponseEntity.ok(images);
     }
 
 }

--- a/src/main/java/com/goorm/team9/icontact/domain/client/converter/ClientConverter.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/client/converter/ClientConverter.java
@@ -12,15 +12,12 @@ public class ClientConverter {
         clientResponseDTO.setId(clientEntity.getId());
         clientResponseDTO.setNickName(clientEntity.getNickName());
         clientResponseDTO.setEmail(clientEntity.getEmail());
-        clientResponseDTO.setRole(clientEntity.getRole().getDescription()); // ENUM → description
+        clientResponseDTO.setRole(clientEntity.getRole().getDescription());
         clientResponseDTO.setCareer(clientEntity.getCareer() != null ? clientEntity.getCareer().getDescription() : null);
         clientResponseDTO.setStatus(clientEntity.getStatus().getDescription());
         clientResponseDTO.setIntroduction(clientEntity.getIntroduction());
         clientResponseDTO.setLink(clientEntity.getLink());
         clientResponseDTO.setProfileImage(clientEntity.getProfileImage());
-//        clientResponseDTO.setChatOpportunity(clientEntity.getChatOpportunity());
-//        clientResponseDTO.setChatMessage(clientEntity.getChatMessage());
-//        clientResponseDTO.setOffline(clientEntity.isOffline());
         clientResponseDTO.setCreatedAt(clientEntity.getCreated_at());
         clientResponseDTO.setUpdatedAt(clientEntity.getUpdated_at());
 

--- a/src/main/java/com/goorm/team9/icontact/domain/client/dto/response/ClientProfileImageDTO.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/client/dto/response/ClientProfileImageDTO.java
@@ -1,0 +1,11 @@
+package com.goorm.team9.icontact.domain.client.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ClientProfileImageDTO {
+    private Long clientId;
+    private String profileImageUrl;
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/client/service/ClientService.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/client/service/ClientService.java
@@ -5,6 +5,7 @@ import com.goorm.team9.icontact.common.exception.CustomException;
 import com.goorm.team9.icontact.domain.client.converter.ClientConverter;
 import com.goorm.team9.icontact.domain.client.dto.request.MyPageCreateRequest;
 import com.goorm.team9.icontact.domain.client.dto.request.MyPageUpdateRequest;
+import com.goorm.team9.icontact.domain.client.dto.response.ClientProfileImageDTO;
 import com.goorm.team9.icontact.domain.client.dto.response.ClientResponseDTO;
 import com.goorm.team9.icontact.domain.client.entity.ClientEntity;
 import com.goorm.team9.icontact.domain.client.entity.TopicEntity;
@@ -122,6 +123,16 @@ public class ClientService {
         return clients.stream()
                 .map(clientConverter::toResponseDTO)
                 .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<ClientProfileImageDTO> getProfileImages(List<Long> clientIds) {
+        return clientIds.stream()
+                .map(id -> clientRepository.findByIdAndIsDeletedFalse(id)
+                        .map(client -> new ClientProfileImageDTO(client.getId(),
+                                client.getProfileImage() != null ? client.getProfileImage() : imageFileStorageService.getDefaultImage()))
+                        .orElse(new ClientProfileImageDTO(id, imageFileStorageService.getDefaultImage())))
+                .toList();
     }
 
 }

--- a/src/main/java/com/goorm/team9/icontact/domain/client/service/S3ImageStorageService.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/client/service/S3ImageStorageService.java
@@ -30,13 +30,11 @@ public class S3ImageStorageService {
 
     public String storeFile(MultipartFile file) {
         try {
-            // 파일명을 UUID로 변환하여 중복 방지
             String uniqueFileName = PROFILE_IMAGE_FOLDER + UUID.randomUUID() + "_" + file.getOriginalFilename();
 
             try (InputStream is = file.getInputStream()) {
-                // S3에 파일 업로드
                 S3Resource upload = s3Template.upload(bucketName, uniqueFileName, is);
-                return upload.getURL().toString(); // 업로드된 S3 URL 반환
+                return upload.getURL().toString();
             }
         } catch (IOException | S3Exception e) {
             throw new RuntimeException("파일 업로드 실패", e);


### PR DESCRIPTION
## 📋 Summary

> - closes #101 
> - **주변 탐색 레이더에 사용될 이미지를 반환해주는 기능 개발**


## ✅ Tasks

- **ClientProfileImageDTO.java** 추가
- `/api/client/profile/profile-images` 엔드포인트 추가
- 서비스 로직에` getProfileImages `메서드 추가

## ✏️ To Reviewer

- 레이더에 활용할 API 를 미리 만들었습니다. 활용가능하면 사용하기면 되고 후에 사용하지 않게 된다면 전체 코드 리펙토링 시에 제거하겠습니다.
- 탐색 인원을 고려하여 최소 0명, 최대 10명까지 요청 가능하게 했습니다.
- 쿼리 파라미터 형식으로 구현하여서 프론트에서 보다 사용을 간편하게 하게 하였습니다.

## 📷 Screenshot

<img width="1153" alt="스크린샷 2025-03-25 오후 8 59 17" src="https://github.com/user-attachments/assets/16d2fa7c-76fd-4b6d-9f9e-01905a506208" />

<img width="1122" alt="스크린샷 2025-03-25 오후 8 59 31" src="https://github.com/user-attachments/assets/ef4f1cbb-15fd-4b89-8dfc-510f71e1e1ef" />

