### PR TITLE
[#107] 위치 탐색 반경 기본값을 10m에서 50m로 수정

### DIFF
--- a/src/main/java/com/goorm/team9/icontact/domain/location/service/LocationService.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/location/service/LocationService.java
@@ -27,7 +27,7 @@ public class LocationService {
     private final RedisTemplate<String, String> redisTemplate;
     private final JdbcTemplate jdbcTemplate;
 
-    @Value("${app.geo.search-radius:10}")
+    @Value("${app.geo.search-radius:50}")
     private double searchRadius;
 
     public boolean saveUserInformation(Long id, double latitude, double longitude) {


### PR DESCRIPTION
## 📋 Summary

> #107 
> - 위치 탐색 반경 기본값 변경


## ✅ Tasks

- 위치 탐색 반경 기본값을 10m에서 50m로 수정합니다.

## ✏️ To Reviewer

위치조회 오차범위를 확인하기 위해 위치 탐색 반경 기본값만 변경했으므로 바로 merge하겠습니다.
