### PR TITLE
[#104] 테스트 코드 작성 및 관심사 API 수정

### DIFF
--- a/src/main/java/com/goorm/team9/icontact/IContactApplication.java
+++ b/src/main/java/com/goorm/team9/icontact/IContactApplication.java
@@ -2,10 +2,8 @@ package com.goorm.team9.icontact;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication(scanBasePackages = "com.goorm.team9.icontact")
-@EnableJpaAuditing
 public class IContactApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/goorm/team9/icontact/common/error/ClientErrorCode.java
+++ b/src/main/java/com/goorm/team9/icontact/common/error/ClientErrorCode.java
@@ -18,4 +18,8 @@ public enum ClientErrorCode implements ErrorCodeInterface {
     private final Integer httpStatusCode;
     private final Integer errorCode;
     private final String description;
+
+    public String getMessage() {
+        return description;
+    }
 }

--- a/src/main/java/com/goorm/team9/icontact/config/jpa/JpaConfig.java
+++ b/src/main/java/com/goorm/team9/icontact/config/jpa/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.goorm.team9.icontact.config.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/client/controller/EnumController.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/client/controller/EnumController.java
@@ -1,12 +1,7 @@
 package com.goorm.team9.icontact.domain.client.controller;
 
-import com.goorm.team9.icontact.domain.client.enums.Career;
-import com.goorm.team9.icontact.domain.client.enums.Interest;
-import com.goorm.team9.icontact.domain.client.enums.Role;
-import com.goorm.team9.icontact.domain.client.enums.Status;
-import com.goorm.team9.icontact.domain.client.enums.Language;
-import com.goorm.team9.icontact.domain.client.enums.Framework;
-import com.goorm.team9.icontact.domain.common.EnumWithDescription;
+import com.goorm.team9.icontact.domain.client.enums.*;
+import com.goorm.team9.icontact.domain.client.service.ClientEnumService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -16,10 +11,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/client/enums")
@@ -27,66 +20,47 @@ import java.util.stream.Collectors;
 @Tag(name = "Enum List API", description = "마이페이지 작성에 사용될 드롭다운 항목들을 관리하는 API 입니다.")
 public class EnumController {
 
+    private final ClientEnumService clientEnumService;
+
     @GetMapping("/roles")
     @Operation(summary = "직업 형태 API", description = "직업의 종류를 출력하는 API입니다.")
     public ResponseEntity<List<Map<String, Object>>> getRoles() {
-        return ResponseEntity.ok(getEnumListWithApiCode(Role.values()));
+        return ResponseEntity.ok(clientEnumService.getEnumListWithApiCode(Role.values()));
     }
 
     @GetMapping("/statuses")
     @Operation(summary = "공개여부 API", description = "공개 여부의 종류를 출력하는 API입니다.")
     public ResponseEntity<List<Map<String, String>>> getStatuses() {
-        return ResponseEntity.ok(getEnumList(Status.values()));
+        return ResponseEntity.ok(clientEnumService.getEnumList(Status.values()));
     }
 
     @GetMapping("/careers")
     @Operation(summary = "경력 API", description = "선택한 직업에 따라 필터링된 경력 목록을 반환하는 API입니다.")
-    public ResponseEntity<List<Map<String, String>>> getCareers(@RequestParam Role role) {
-        return ResponseEntity.ok(getFilteredCareers(role));
+    public ResponseEntity<List<Map<String, String>>> getCareers(
+            @RequestParam Role role
+    ) {
+        return ResponseEntity.ok(clientEnumService.getFilteredCareers(role));
     }
-
 
     @GetMapping("/frameworks")
     @Operation(summary = "프레임워크 API", description = "프레임워크의 종류를 출력하는 API입니다.")
     public ResponseEntity<List<Map<String, String>>> getFrameworks() {
-        return ResponseEntity.ok(getEnumList(Framework.values()));
+        return ResponseEntity.ok(clientEnumService.getEnumList(Framework.values()));
     }
 
     @GetMapping("/languages")
     @Operation(summary = "언어 API", description = "언어의 종류를 출력하는 API입니다.")
     public ResponseEntity<List<Map<String, String>>> getLanguage() {
-        return ResponseEntity.ok(getEnumList(Language.values()));
+        return ResponseEntity.ok(clientEnumService.getEnumList(Language.values()));
     }
 
     @GetMapping("/interests")
-    @Operation(summary = "관심 주제 API", description = "관심 주제의 종류를 출력하는 API입니다.")
-    public ResponseEntity<List<Map<String, String>>> getInterest() {
-        return ResponseEntity.ok(getEnumList(Interest.values()));
+    @Operation(summary = "관심 주제 API", description = "선택한 분야(DEV, PD, DS)에 따라 관심 주제 목록을 반환합니다.")
+    public ResponseEntity<List<Map<String, String>>> getInterests(
+            @RequestParam InterestCategory category
+    ) {
+        return ResponseEntity.ok(clientEnumService.getFilteredInterestsByApiCode(category.name()));
     }
 
-    private <E extends Enum<E> & EnumWithDescription> List<Map<String, String>> getEnumList(E[] values) {
-        return Arrays.stream(values)
-                .map(e -> Map.of("key", e.name(), "description", e.getDescription()))
-                .collect(Collectors.toList());
-    }
-
-    private List<Map<String, Object>> getEnumListWithApiCode(Role[] values) {
-        return Arrays.stream(values)
-                .map(e -> Map.<String, Object>of(
-                        "key", e.name(),
-                        "description", e.getDescription(),
-                        "apiCode", Integer.valueOf(e.getApiCode())
-                ))
-                .collect(Collectors.toList());
-    }
-
-    private List<Map<String, String>> getFilteredCareers(Role role) {
-        int apiCode = role.getApiCode();
-
-        return Arrays.stream(Career.values())
-                .filter(c -> c.getApiCode() == apiCode)
-                .map(c -> Map.of("key", c.name(), "description", c.getDescription()))
-                .collect(Collectors.toList());
-    }
 }
 

--- a/src/main/java/com/goorm/team9/icontact/domain/client/dto/request/MyPageCreateRequest.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/client/dto/request/MyPageCreateRequest.java
@@ -7,11 +7,15 @@ import com.goorm.team9.icontact.domain.client.enums.Language;
 import com.goorm.team9.icontact.domain.client.enums.Status;
 import com.goorm.team9.icontact.domain.client.enums.Role;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor
 @Schema(description = "마이페이지 생성 요청 DTO", example = "{\n" +
         "  \"nickName\": \"Noah\",\n" +
         "  \"email\": \"noah@gmail.com\",\n" +

--- a/src/main/java/com/goorm/team9/icontact/domain/client/dto/request/MyPageUpdateRequest.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/client/dto/request/MyPageUpdateRequest.java
@@ -2,11 +2,15 @@ package com.goorm.team9.icontact.domain.client.dto.request;
 
 import com.goorm.team9.icontact.domain.client.enums.*;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor
 @Schema(description = "마이페이지 수정 요청 DTO", example = "{\n" +
         "  \"nickName\": \"NoahUpdated\",\n" +
         "  \"role\": \"DEV\",\n" +

--- a/src/main/java/com/goorm/team9/icontact/domain/client/dto/response/ClientProfileImageDTO.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/client/dto/response/ClientProfileImageDTO.java
@@ -1,9 +1,11 @@
 package com.goorm.team9.icontact.domain.client.dto.response;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
 @AllArgsConstructor
 public class ClientProfileImageDTO {
     private Long clientId;

--- a/src/main/java/com/goorm/team9/icontact/domain/client/enums/InterestCategory.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/client/enums/InterestCategory.java
@@ -1,0 +1,5 @@
+package com.goorm.team9.icontact.domain.client.enums;
+
+public enum InterestCategory {
+    DEV, PD, DS
+}

--- a/src/main/java/com/goorm/team9/icontact/domain/client/service/ClientEnumService.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/client/service/ClientEnumService.java
@@ -1,0 +1,47 @@
+package com.goorm.team9.icontact.domain.client.service;
+
+import com.goorm.team9.icontact.domain.client.enums.Career;
+import com.goorm.team9.icontact.domain.client.enums.Interest;
+import com.goorm.team9.icontact.domain.client.enums.Role;
+import com.goorm.team9.icontact.domain.common.EnumWithDescription;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+public class ClientEnumService {
+
+    public <E extends Enum<E> & EnumWithDescription> List<Map<String, String>> getEnumList(E[] values) {
+        return Arrays.stream(values)
+                .map(e -> Map.of("key", e.name(), "description", e.getDescription()))
+                .collect(Collectors.toList());
+    }
+
+    public List<Map<String, Object>> getEnumListWithApiCode(Role[] values) {
+        return Arrays.stream(values)
+                .map(e -> Map.<String, Object>of(
+                        "key", e.name(),
+                        "description", e.getDescription(),
+                        "apiCode", e.getApiCode()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    public List<Map<String, String>> getFilteredCareers(Role role) {
+        return Arrays.stream(Career.values())
+                .filter(c -> c.getApiCode() == role.getApiCode())
+                .map(c -> Map.of("key", c.name(), "description", c.getDescription()))
+                .collect(Collectors.toList());
+    }
+
+    public List<Map<String, String>> getFilteredInterestsByApiCode(String apiCode) {
+        return Arrays.stream(Interest.values())
+                .filter(interest -> interest.getApiCode().equalsIgnoreCase(apiCode))
+                .map(interest -> Map.of("key", interest.name(), "description", interest.getDescription()))
+                .collect(Collectors.toList());
+    }
+}
+

--- a/src/test/java/com/goorm/team9/icontact/client/ClientControllerTest.java
+++ b/src/test/java/com/goorm/team9/icontact/client/ClientControllerTest.java
@@ -1,0 +1,147 @@
+package com.goorm.team9.icontact.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goorm.team9.icontact.domain.client.controller.ClientController;
+import com.goorm.team9.icontact.domain.client.converter.ClientConverter;
+import com.goorm.team9.icontact.domain.client.dto.request.MyPageCreateRequest;
+import com.goorm.team9.icontact.domain.client.dto.request.MyPageUpdateRequest;
+import com.goorm.team9.icontact.domain.client.dto.response.ClientProfileImageDTO;
+import com.goorm.team9.icontact.domain.client.dto.response.ClientResponseDTO;
+import com.goorm.team9.icontact.domain.client.enums.Role;
+import com.goorm.team9.icontact.domain.client.enums.Status;
+import com.goorm.team9.icontact.domain.client.service.ClientService;
+import com.goorm.team9.icontact.domain.client.service.S3ImageStorageService;
+import org.apiguardian.api.API;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WithMockUser(username = "testUser")
+@WebMvcTest(controllers = ClientController.class,
+        excludeAutoConfiguration = {
+                org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration.class,
+                org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration.class
+        })
+class ClientControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private S3ImageStorageService s3ImageStorageService;
+
+    @MockitoBean
+    private ClientConverter clientConverter;
+
+    @MockitoBean
+    private ClientService clientService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("마이페이지 생성 API 성공 테스트")
+    void 마이페이지_생성_테스트() throws Exception {
+        MyPageCreateRequest request = MyPageCreateRequest.builder()
+                .email("test@example.com")
+                .nickName("테스터")
+                .role(Role.DEV)
+                .status(Status.PUBLIC)
+                .provider("kakao")
+                .build();
+
+        MockMultipartFile image = new MockMultipartFile("profileImage", "test.jpg", "image/jpeg", "img".getBytes());
+        MockMultipartFile userData = new MockMultipartFile("userData", "", "text/plain",
+                objectMapper.writeValueAsString(request).getBytes());
+
+        when(clientService.createMyPage(any(), any())).thenReturn(new ClientResponseDTO());
+
+        mockMvc.perform(multipart("/api/client/profile")
+                        .file(image)
+                        .file(userData)
+                        .with(csrf())
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isOk());
+
+    }
+
+    @Test
+    @DisplayName("마이페이지 수정 API 성공 테스트")
+    void 마이페이지_수정_테스트() throws Exception {
+        MyPageUpdateRequest request = MyPageUpdateRequest.builder()
+                .nickName("업데이트됨")
+                .build();
+
+        MockMultipartFile image = new MockMultipartFile("profileImage", "update.jpg", "image/jpeg", "img".getBytes());
+        MockMultipartFile userData = new MockMultipartFile("userData", "", "application/json",
+                objectMapper.writeValueAsBytes(request));
+
+        when(clientService.updateUser(eq(1L), any(), any())).thenReturn(new ClientResponseDTO());
+
+        mockMvc.perform(multipart("/api/client/profile/update/1")
+                        .file(image)
+                        .file(userData)
+                        .with(csrf())
+                        .with(req -> {
+                            req.setMethod("PATCH");
+                            return req;
+                        })
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isOk());
+
+    }
+
+    @Test
+    @DisplayName("특정 사용자 조회 API 성공 테스트")
+    void 사용자_조회_테스트() throws Exception {
+        when(clientService.getUserById(1L)).thenReturn(new ClientResponseDTO());
+
+        mockMvc.perform(get("/api/client/profile/1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("전체 사용자 조회 API 성공 테스트")
+    void 전체_사용자_조회_테스트() throws Exception {
+        when(clientService.getAllClients()).thenReturn(List.of(new ClientResponseDTO()));
+
+        mockMvc.perform(get("/api/client/profile/all"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 목록 조회 API 성공 테스트")
+    void 프로필_이미지_목록_조회_테스트() throws Exception {
+        when(clientService.getProfileImages(any())).thenReturn(List.of(
+                new ClientProfileImageDTO(1L, "https://test-image.com/profile.jpg")
+        ));
+
+        mockMvc.perform(get("/api/client/profile/profile-images")
+                        .param("clientIds", "1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("clientId 10개 초과시 실패 테스트")
+    void 프로필_이미지_목록_조회_실패_테스트() throws Exception {
+        mockMvc.perform(get("/api/client/profile/profile-images")
+                        .param("clientIds", "1,2,3,4,5,6,7,8,9,10,11"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/goorm/team9/icontact/client/ClientServiceTest.java
+++ b/src/test/java/com/goorm/team9/icontact/client/ClientServiceTest.java
@@ -1,0 +1,167 @@
+package com.goorm.team9.icontact.client;
+
+import com.goorm.team9.icontact.common.error.ClientErrorCode;
+import com.goorm.team9.icontact.common.exception.CustomException;
+import com.goorm.team9.icontact.domain.client.converter.ClientConverter;
+import com.goorm.team9.icontact.domain.client.dto.request.MyPageCreateRequest;
+import com.goorm.team9.icontact.domain.client.dto.request.MyPageUpdateRequest;
+import com.goorm.team9.icontact.domain.client.dto.response.ClientProfileImageDTO;
+import com.goorm.team9.icontact.domain.client.dto.response.ClientResponseDTO;
+import com.goorm.team9.icontact.domain.client.entity.ClientEntity;
+import com.goorm.team9.icontact.domain.client.entity.TopicEntity;
+import com.goorm.team9.icontact.domain.client.enums.Role;
+import com.goorm.team9.icontact.domain.client.enums.Status;
+import com.goorm.team9.icontact.domain.client.repository.ClientRepository;
+import com.goorm.team9.icontact.domain.client.service.ClientService;
+import com.goorm.team9.icontact.domain.client.service.S3ImageStorageService;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ClientServiceTest {
+
+    @InjectMocks
+    private ClientService clientService;
+
+    @Mock private ClientRepository clientRepository;
+    @Mock private ClientConverter clientConverter;
+    @Mock private S3ImageStorageService imageStorageService;
+
+    private ClientEntity mockClient;
+    private TopicEntity mockTopic;
+    private MultipartFile mockFile;
+
+    @BeforeEach
+    void setup() {
+        mockTopic = TopicEntity.builder().build();
+        mockClient = ClientEntity.builder()
+                .id(1L)
+                .nickName("Noah")
+                .email("noah@example.com")
+                .provider("kakao")
+                .role(Role.DEV)
+                .status(Status.PUBLIC)
+                .it_topic(mockTopic)
+                .profileImage("profile.jpg")
+                .build();
+
+        mockFile = new MockMultipartFile("profileImage", "test.jpg", "image/jpeg", "fake-image".getBytes());
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("마이페이지 성공 테스트")
+    void 마이페이지_생성_성공_테스트() {
+        // given
+        MyPageCreateRequest request = MyPageCreateRequest.builder()
+                .email("noah@example.com")
+                .nickName("Noah")
+                .role(Role.DEV)
+                .status(Status.PUBLIC)
+                .provider("kakao")
+                .build();
+
+        given(clientRepository.existsByEmail(request.getEmail())).willReturn(false);
+        given(imageStorageService.storeFile(mockFile)).willReturn("profile.jpg");
+        given(clientRepository.save(any(ClientEntity.class))).willReturn(mockClient);
+        given(clientConverter.toResponseDTO(any())).willReturn(new ClientResponseDTO());
+
+        // when
+        ClientResponseDTO result = clientService.createMyPage(request, mockFile);
+
+        // then
+        assertThat(result).isNotNull();
+        verify(clientRepository).save(any());
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("공개 상태 사용자 정보 조회 테스트")
+    void 사용자ID로_공개상태_사용자_조회_테스트() {
+        // given
+        given(clientRepository.findByIdAndIsDeletedFalse(1L)).willReturn(Optional.of(mockClient));
+        given(clientConverter.toResponseDTO(mockClient)).willReturn(new ClientResponseDTO());
+
+        // when
+        ClientResponseDTO result = clientService.getUserById(1L);
+
+        // then
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("비공개 상태 사용자 정보 조회 테스트")
+    void 사용자ID로_비공개상태_사용자_조회_테스트() {
+        mockClient.setStatus(Status.PRIVATE);
+        given(clientRepository.findByIdAndIsDeletedFalse(1L)).willReturn(Optional.of(mockClient));
+
+        assertThatThrownBy(() -> clientService.getUserById(1L))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ClientErrorCode.STATUS_IS_PRIVATE.getMessage());
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("상용자 정보 업데이트 테스트")
+    void 사용자_정보_업데이트_테스트() {
+        // given
+        MyPageUpdateRequest request = MyPageUpdateRequest.builder()
+                .nickName("Updated")
+                .status(Status.PUBLIC)
+                .build();
+
+        given(clientRepository.findById(1L)).willReturn(Optional.of(mockClient));
+        given(clientRepository.save(mockClient)).willReturn(mockClient);
+        given(clientConverter.toResponseDTO(mockClient)).willReturn(new ClientResponseDTO());
+
+        // when
+        ClientResponseDTO result = clientService.updateUser(1L, request, mockFile);
+
+        // then
+        assertThat(result).isNotNull();
+        verify(clientRepository).save(mockClient);
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("전체 사용자 조회 테스트")
+    void 전체_사용자_조회_테스트() {
+        given(clientRepository.findAllByIsDeletedFalse()).willReturn(List.of(mockClient));
+        given(clientConverter.toResponseDTO(mockClient)).willReturn(new ClientResponseDTO());
+
+        List<ClientResponseDTO> result = clientService.getAllClients();
+
+        assertThat(result).isNotEmpty();
+        verify(clientRepository).findAllByIsDeletedFalse();
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("프로필 미등록 생성 계정의 이미지 반환 테스트")
+    void 마이페이지_생성_후_가본이미지_반환_테스트() {
+        given(clientRepository.findByIdAndIsDeletedFalse(anyLong())).willReturn(Optional.empty());
+        given(imageStorageService.getDefaultImage()).willReturn("default.jpg");
+
+        List<ClientProfileImageDTO> result = clientService.getProfileImages(List.of(99L));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getProfileImageUrl()).isEqualTo("default.jpg");
+    }
+}


### PR DESCRIPTION
## 📋 Summary

> - closes #104 
> - **테스트 코드 작성 및 관심사 API 수정**

## ✅ Tasks

> - 사용자 관련 단위 테스트 코드를 작성합니다.
> - 관심사 API를 apiCode기준으로 출력하게 변경합니다.
> - 기존 EnumController에 있던 메서드를 EnumService.java에 이전합니다.

## ✏️ To Reviewer

> - 해당 API를 사용해야하는 시점이기에 PR후 11시35이 되거나 어프룹이 있으면 바로 병합 진행하겠습니다!

## 📷 Screenshot

<img width="1624" alt="스크린샷 2025-03-26 오후 11 21 01" src="https://github.com/user-attachments/assets/ba016e26-0259-4a1a-8428-d34d41f3abf9" />

<img width="1624" alt="스크린샷 2025-03-26 오후 11 21 16" src="https://github.com/user-attachments/assets/15a96379-9ff2-4c66-a569-b333c1590070" />
