### PR TITLE
[#124] 채팅 리팩토링 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/goorm/team9/icontact/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/controller/ChatRoomController.java
@@ -35,19 +35,25 @@ public class ChatRoomController {
             @RequestBody
             @Schema(example = "{\"roomId\": 123, \"clientId\": 456}")
             Map<String, Long> request) {
+        try {
+            Long roomId = request.get("roomId");
+            Long clientId = request.get("clientId");
 
-        Long roomId = request.get("roomId");
-        Long clientId = request.get("clientId");
+            if (roomId == null || clientId == null) {
+               return ResponseEntity.badRequest().body(Map.of("error", "roomId 또는 clientId가 비어 있습니다."));
+            }
 
-        ClientEntity client = clientRepository.findById(clientId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+            ClientEntity client = clientRepository.findById(clientId)
+                    .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
-        chatRoomService.exitChatRoom(roomId, clientId);
+            chatRoomService.exitChatRoom(roomId, clientId);
 
-        Map<String, String> response = new HashMap<>();
-        response.put("message", client.getNickName() + "님이 퇴장했습니다.");
-
-        return ResponseEntity.ok(response);
+            return ResponseEntity.ok(Map.of("message", client.getNickName() + "님이 퇴장했습니다."));
+        } catch(IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", e.getMessage()));
+        } catch(Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("error", "서버 오류"));
+        }
     }
 
     @Operation(summary = "채팅방 입장 API", description = "사용자가 채팅방에 입장하면 last_read_at을 업데이트합니다.")

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/dto/ChatRequestDto.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/dto/ChatRequestDto.java
@@ -22,12 +22,15 @@ public class ChatRequestDto {
 
     private String status;
 
+    private boolean exited;
+
     public static ChatRequestDto fromEntity(ChatRequest chatRequest) {
         return ChatRequestDto.builder()
                 .id(chatRequest.getId())
                 .senderNickname(chatRequest.getSenderNickname())
                 .receiverNickname(chatRequest.getReceiverNickname())
                 .status(chatRequest.getStatus().toString())
+                .exited(false)
                 .build();
     }
 }

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/dto/ChatRoomRequest.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/dto/ChatRoomRequest.java
@@ -1,10 +1,12 @@
 package com.goorm.team9.icontact.domain.chat.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class ChatRoomRequest {
     private String senderNickname;
     private String receiverNickname;

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/dto/ChatRoomResponse.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/dto/ChatRoomResponse.java
@@ -15,14 +15,22 @@ public class ChatRoomResponse {
     private String lastMessage;
     private LocalDateTime lastMessageTime;
     private Long unreadCount;
+    private boolean exited;
+    private Long otherId;
 
-    public static ChatRoomResponse fromEntity(ChatRoom chatRoom, Long unreadCount) {
+    public static ChatRoomResponse fromEntity(ChatRoom chatRoom, Long unreadCount, boolean exited, Long myId) {
+        Long otherId = chatRoom.getSenderNickname().getId().equals(myId)
+                ? chatRoom.getReceiverNickname().getId()
+                : chatRoom.getSenderNickname().getId();
+
         return new ChatRoomResponse(
                 chatRoom.getRoomId(),
                 List.of(chatRoom.getSenderNickname().getNickName(), chatRoom.getReceiverNickname().getNickName()),
                 chatRoom.getLastMessage() != null ? chatRoom.getLastMessage() : "새 메시지가 없습니다.",
                 chatRoom.getLastMessageTime(),
-                unreadCount
+                unreadCount,
+                exited,
+                otherId
         );
     }
 }

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/repository/ChatRequestRepository.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/repository/ChatRequestRepository.java
@@ -2,7 +2,6 @@ package com.goorm.team9.icontact.domain.chat.repository;
 
 import com.goorm.team9.icontact.domain.chat.entity.ChatRequest;
 import com.goorm.team9.icontact.domain.chat.entity.RequestStatus;
-import com.goorm.team9.icontact.domain.client.entity.ClientEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -35,5 +34,4 @@ public interface ChatRequestRepository extends JpaRepository<ChatRequest, Long> 
     long countSentRequests(@Param("sender") String sender, @Param("status") RequestStatus status);
 
     List<ChatRequest> status(RequestStatus status);
-
 }

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/repository/ChatRoomRepository.java
@@ -43,4 +43,9 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             "FROM ChatRoom c " +
             "ORDER BY (SELECT MAX(m.created_at) FROM ChatMessage m WHERE m.chatRoom = c) DESC")
     List<Object[]> findAllChatRoomsWithUnreadCount(@Param("clientId") Long clientId);
+
+    @Query("SELECT cr FROM ChatRoom cr WHERE " +
+            "(cr.senderNickname.nickName = :sender AND cr.receiverNickname.nickName = :receiver) " +
+            "OR (cr.senderNickname.nickName = :receiver AND cr.receiverNickname.nickName = :sender)")
+    Optional<ChatRoom> findBySenderAndReceiver(@Param("sender") String sender, @Param("receiver") String receiver);
 }

--- a/src/main/java/com/goorm/team9/icontact/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/goorm/team9/icontact/domain/chat/repository/ChatRoomRepository.java
@@ -37,13 +37,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             "ORDER BY (SELECT MAX(m.created_at) FROM ChatMessage m WHERE m.chatRoom = c) DESC")
     List<Object[]> findAllChatRoomsWithUnreadCount(@Param("nickname") String nickname, @Param("clientId") Long clientId);
 
-    @Query("SELECT c, " +
-            "(SELECT COUNT(m) FROM ChatMessage m WHERE m.chatRoom = c AND m.created_at > " +
-            "(SELECT cj.lastReadAt FROM ChatJoin cj WHERE cj.chatRoom = c AND cj.client.id = :clientId)) " +
-            "FROM ChatRoom c " +
-            "ORDER BY (SELECT MAX(m.created_at) FROM ChatMessage m WHERE m.chatRoom = c) DESC")
-    List<Object[]> findAllChatRoomsWithUnreadCount(@Param("clientId") Long clientId);
-
     @Query("SELECT cr FROM ChatRoom cr WHERE " +
             "(cr.senderNickname.nickName = :sender AND cr.receiverNickname.nickName = :receiver) " +
             "OR (cr.senderNickname.nickName = :receiver AND cr.receiverNickname.nickName = :sender)")

--- a/src/test/java/com/goorm/team9/icontact/chat/controller/ChatRequestControllerTest.java
+++ b/src/test/java/com/goorm/team9/icontact/chat/controller/ChatRequestControllerTest.java
@@ -1,0 +1,146 @@
+package com.goorm.team9.icontact.chat.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goorm.team9.icontact.domain.chat.controller.ChatRequestController;
+import com.goorm.team9.icontact.domain.chat.dto.ChatRequestCountDto;
+import com.goorm.team9.icontact.domain.chat.dto.ChatRequestDto;
+import com.goorm.team9.icontact.domain.chat.dto.ChatResponseDto;
+import com.goorm.team9.icontact.domain.chat.entity.RequestStatus;
+import com.goorm.team9.icontact.domain.chat.service.ChatRequestService;
+import com.goorm.team9.icontact.domain.chat.service.ChatRoomService;
+import com.goorm.team9.icontact.domain.client.entity.ClientEntity;
+import com.goorm.team9.icontact.domain.client.repository.ClientRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WithMockUser
+@WebMvcTest(controllers = ChatRequestController.class)
+class ChatRequestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ChatRequestService chatRequestService;
+
+    @MockitoBean
+    private ChatRoomService chatRoomService;
+
+    @MockitoBean
+    private ClientRepository clientRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("채팅 요청 성공 시 DB에 저장하고 응답을 확인한다.")
+    void 채팅요청_성공_테스트() throws Exception {
+        ChatRequestDto requestDto = ChatRequestDto.builder()
+                .senderNickname("Noah1")
+                .receiverNickname("Noah2")
+                .build();
+
+        ChatResponseDto responseDto = new ChatResponseDto(
+                100L,
+                "채팅 요청이 정상적으로 전송되었습니다.",
+                null
+        );
+
+        ClientEntity sender = new ClientEntity();
+        sender.setNickName("Noah1");
+        ClientEntity receiver = new ClientEntity();
+        receiver.setNickName("Noah2");
+
+        when(clientRepository.findByNickName("Noah1")).thenReturn(Optional.of(sender));
+        when(clientRepository.findByNickName("Noah2")).thenReturn(Optional.of(receiver));
+        when(chatRequestService.requestChat(any(), any())).thenReturn(ResponseEntity.ok(responseDto));
+
+        mockMvc.perform(post("/api/chat/request")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.requestId").value(100L))
+                .andExpect(jsonPath("$.message").value("채팅 요청이 정상적으로 전송되었습니다."));
+    }
+
+    @Test
+    @DisplayName("채팅 요청 승인 시 채팅방이 생성되고 roomId를 반환한다.")
+    void 채팅요청_승인_테스트() throws Exception {
+        when(chatRequestService.acceptChatRequest(1L))
+                .thenReturn(999L);
+
+        mockMvc.perform(patch("/api/chat/request/accept/1")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("채팅 요청이 수락되었습니다."))
+                .andExpect(jsonPath("$.roomId").value(999L));
+    }
+
+    @Test
+    @DisplayName("채팅 요청 거절 시 상태가 변경되고 거절 메시지를 반환한다.")
+    void 채팅요청_거절_테스트() throws Exception {
+        mockMvc.perform(patch("/api/chat/request/reject/1")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("채팅 요청이 거절되었습니다."));
+
+    }
+
+    @Test
+    @DisplayName("받은 채팅 요청 목록을 조회한다.")
+    void 받은요청_조회_테스트() throws Exception {
+        when(chatRequestService.getReceivedRequests("Noah2", RequestStatus.PENDING))
+                .thenReturn(List.of());
+
+        mockMvc.perform(get("/api/chat/request/received")
+                .param("receiverNickname", "Noah2")
+                .param("status", "PENDING"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("보낸 채팅 요청 목록을 조회한다.")
+    void 보낸요청_조회_테스트() throws Exception {
+        when(chatRequestService.getSentRequest("Noah1", RequestStatus.PENDING))
+                .thenReturn(List.of());
+
+        mockMvc.perform(get("/api/chat/request/sent")
+                .param("senderNickname", "Noah1")
+                .param("status", "PENDING"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("채팅 요청 개수를 조회한다.")
+    void 채팅요청개수_조회_테스트() throws Exception {
+        when(chatRequestService.getRequestCounts("Noah1"))
+                .thenReturn(new ChatRequestCountDto(5L, 3L));
+
+        mockMvc.perform(get("/api/chat/request/count")
+                .param("nickname", "Noah1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sentCount").value(3L))
+                .andExpect(jsonPath("$.receivedCount").value(5L));
+
+    }
+
+
+
+}

--- a/src/test/java/com/goorm/team9/icontact/chat/controller/ChatRequestControllerTest.java
+++ b/src/test/java/com/goorm/team9/icontact/chat/controller/ChatRequestControllerTest.java
@@ -140,7 +140,4 @@ class ChatRequestControllerTest {
                 .andExpect(jsonPath("$.receivedCount").value(5L));
 
     }
-
-
-
 }

--- a/src/test/java/com/goorm/team9/icontact/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/goorm/team9/icontact/chat/controller/ChatRoomControllerTest.java
@@ -1,0 +1,140 @@
+package com.goorm.team9.icontact.chat.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goorm.team9.icontact.domain.chat.controller.ChatRoomController;
+import com.goorm.team9.icontact.domain.chat.dto.ChatRoomRequest;
+import com.goorm.team9.icontact.domain.chat.dto.ChatRoomResponse;
+import com.goorm.team9.icontact.domain.chat.service.ChatRoomService;
+import com.goorm.team9.icontact.domain.client.entity.ClientEntity;
+import com.goorm.team9.icontact.domain.client.repository.ClientRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ChatRoomController.class)
+@WithMockUser
+public class ChatRoomControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ChatRoomService chatRoomService;
+
+    @MockitoBean
+    private ClientRepository clientRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("채팅방 생성을 성공한다.")
+    void 채팅방_생성_성공_테스트() throws Exception {
+        ChatRoomRequest request = new ChatRoomRequest("Noah1", "Noah2");
+
+        ClientEntity sender = new ClientEntity();
+        sender.setNickName("Noah1");
+
+        ClientEntity receiver = new ClientEntity();
+        receiver.setNickName("Noah2");
+
+        when(clientRepository.findByNickName("Noah1")).thenReturn(Optional.of(sender));
+        when(clientRepository.findByNickName("Noah2")).thenReturn(Optional.of(receiver));
+        when(chatRoomService.createChatRoom(sender, receiver)).thenReturn(101L);
+
+        mockMvc.perform(post("/api/chat")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.roomId").value(101L))
+                .andExpect(jsonPath("$.data.senderNickname").value("Noah1"))
+                .andExpect(jsonPath("$.data.receiverNickname").value("Noah2"))
+                .andExpect(jsonPath("$.message").value("채팅방이 생성되었습니다."));
+    }
+
+    @Test
+    @DisplayName("채팅방 퇴장 시 퇴장 메시지를 반환한다.")
+    void 채팅방_퇴장_테스트() throws Exception {
+        ClientEntity client = new ClientEntity();
+        client.setNickName("Noah1");
+
+        when(clientRepository.findById(2L)).thenReturn(Optional.of(client));
+
+        mockMvc.perform(post("/api/chat/exit")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"roomId\": 1, \"clientId\": 2}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Noah1님이 퇴장했습니다."));
+    }
+
+    @Test
+    @DisplayName("채팅방 입장 시 last_read_at 업데이트된다.")
+    void 채팅방_입장_테스트() throws Exception {
+        mockMvc.perform(post("/api/chat/enter")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"roomId\": 1, \"clientId\": 2}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("last_read_at이 업데이트되었습니다."));
+    }
+
+    @Test
+    @DisplayName("최신 메시지순으로 채팅방을 조회한다.")
+    void 최신순_채팅방_조회() throws Exception {
+        ClientEntity client = new ClientEntity();
+        client.setNickName("Noah1");
+
+        ChatRoomResponse response = new ChatRoomResponse(
+                1L,
+                List.of("Noah1", "Noah2"),
+                "안녕하세요",
+                LocalDateTime.now(),
+                2L
+        );
+
+        when(clientRepository.findByNickName("Noah1")).thenReturn(Optional.of(client));
+        when(chatRoomService.getLatestChatRooms(client)).thenReturn(List.of(response));
+
+        mockMvc.perform(get("/api/chat/latest")
+                        .param("nickname", "Noah1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].roomId").value(1L))
+                .andExpect(jsonPath("$[0].participants[0]").value("Noah1"))
+                .andExpect(jsonPath("$[0].participants[1]").value("Noah2"))
+                .andExpect(jsonPath("$[0].lastMessage").value("안녕하세요"))
+                .andExpect(jsonPath("$[0].unreadCount").value(2));
+    }
+
+    @Test
+    @DisplayName("읽지 않은 메시지가 있는 채팅방 목록을 조회한다.")
+    void 읽지않은채팅방_조회() throws Exception {
+        ClientEntity client = new ClientEntity();
+        client.setNickName("Noah1");
+
+        ChatRoomResponse response = new ChatRoomResponse(
+                2L,
+                List.of("Noah1", "Noah2"),
+                "안녕하세요",
+                LocalDateTime.now(),
+                2L
+        );
+    }
+}

--- a/src/test/java/com/goorm/team9/icontact/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/goorm/team9/icontact/chat/controller/ChatRoomControllerTest.java
@@ -107,7 +107,9 @@ public class ChatRoomControllerTest {
                 List.of("Noah1", "Noah2"),
                 "안녕하세요",
                 LocalDateTime.now(),
-                2L
+                2L,
+                false,
+                3L
         );
 
         when(clientRepository.findByNickName("Noah1")).thenReturn(Optional.of(client));
@@ -134,7 +136,9 @@ public class ChatRoomControllerTest {
                 List.of("Noah1", "Noah2"),
                 "안녕하세요",
                 LocalDateTime.now(),
-                2L
+                2L,
+                false,
+                3L
         );
     }
 }

--- a/src/test/java/com/goorm/team9/icontact/chat/service/ChatRequestServiceTest.java
+++ b/src/test/java/com/goorm/team9/icontact/chat/service/ChatRequestServiceTest.java
@@ -186,8 +186,6 @@ public class ChatRequestServiceTest {
     @DisplayName("닉네임 기준으로 받은 요청 목록 반환한다.")
     void getReceivedRequests_success() {
         // Given
-        when(clientRepository.findByNickName("Noah2"))
-                .thenReturn(Optional.of(receiver));
         when(chatRequestRepository.findByReceiverNicknameAndStatus("Noah2", RequestStatus.PENDING))
                 .thenReturn(List.of(ChatRequest.create(sender, receiver)));
 
@@ -202,7 +200,6 @@ public class ChatRequestServiceTest {
     @DisplayName("닉네임 기준으로 보낸 요청 목록 반환한다.")
     void getSentRequests_success() {
         // Given
-        when(clientRepository.findByNickName("Noah1")).thenReturn(Optional.of(sender));
         when(chatRequestRepository.findBySenderNicknameAndStatus("Noah1", RequestStatus.PENDING))
                 .thenReturn(List.of(ChatRequest.create(sender, receiver)));
 

--- a/src/test/java/com/goorm/team9/icontact/websocket/WebSocketSessionServiceTest.java
+++ b/src/test/java/com/goorm/team9/icontact/websocket/WebSocketSessionServiceTest.java
@@ -45,7 +45,7 @@ public class WebSocketSessionServiceTest {
 
         // Verify
         ChatMessageDto capturedMessage = captor.getValue();
-        assertEquals("UserA님이 입장했습니다.", capturedMessage.getContent());
+        assertEquals("UserA님과의 대화가 시작되었어요.", capturedMessage.getContent());
     }
 
     @Test


### PR DESCRIPTION
## 📋 Summary

> - closes #124 
> - 채팅 테스트 코드 작성
> - 채팅방 조회 api에서 상대방 id도 반환되도록 수정
> - 채팅 요청 목록에 퇴장 여부 포함되도록 수정

## ✅ Tasks

- ChatMessageController 테스트 코드 작성
- ChatRequestController 테스트 코드 작성
- ChatRoomController 테스트 코드 작성
- ChatRequestDto에 퇴장 여부 exited 필드 추가
- ChatRoomResponse에 퇴장 여부 exited, 상대방 clientId otherId 필드 추가
- ChatRoomRepository에 findBySenderAndReceiver 메서드 추가
- 채팅 요청 목록에 퇴장 여부 포함되도록 수정
- 채팅방 퇴장 예외 처리
- 채팅 관련 코드에서 불필요한 import문, 메서드 삭제

## ✏️ To Reviewer

요청 상태 | exited | 버튼
-- | -- | --
PENDING | ❎ | 수락 대기 중
ACCEPTED | false | 채팅방으로 이동하기
ACCEPTED | true | 채팅 종료됨(비활성화)
REJECTED | ❎ | 채팅 요청하기

- 위처럼 승인됐을 경우 두 가지 상황을 추가 고려하도록 수정했습니다.

- 채팅 관련 테스트 코드 작성 완료했습니다.

## 📷 Screenshot

